### PR TITLE
ci: fix coverage action for private repos

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,8 @@ jobs:
   report:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Done

- Update coverage reporting action to have the necessary permissions for private repos.

