### PR TITLE
WD-10024 - feat: set up views for groups and roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ yarn-error.log
 !.yarn/sdks
 !.yarn/versions
 
-openapi.yaml
 .pnp.*
 .vite.config.ts.timestamp-*
 demo/public/mockServiceWorker.js

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1131 @@
+openapi: 3.1.0
+info:
+  title: Canonical OpenFGA Administration Product Compatibility API
+  description: |
+    The following specification outlines the API required for the FGA administration frontend to interact with an OpenFGA instance through a products API. This is an evolving specification as reflected in the version number.
+
+    #### Changelog
+    | Version | Notes |
+    |---|---|
+    | **0.0.8** | Implement response type as defined in [IAM Platform Admin UI HTTP Spec](https://docs.google.com/document/d/1ElV22e3mePGFPq8CaM3F3IkuyuOLNpjG7yYgtjvygf4/edit). |
+    | **0.0.7** | Added `/entitlements/raw` endpoint to split `/entitlements` responses. |
+    | **0.0.6** | Ensured compatibility with Orval Restful Client Generator. |
+    | **0.0.5** | Add filter parameter to top level collection `GET` requests. |
+    | **0.0.4** | Added pagination parameters to appropriate `GET` requests.<br />Changed a couple of `PUT`'s to `PATCH`'s to account for the possible subset returned from the paginated `GET`'s. |
+    | **0.0.3** | Added skeleton error responses for `400`, `401`, `404`, and `5XX` (`default`) |
+    | **0.0.2** | Added `GET /users/{id}/groups`<br />Added `GET /users/{id}roles`<br />Added `GET /users/{id}/entitlements`<br />Added `GET,PUT /groups/{id}/users`<br>Added `DELETE /groups/{id}/users/{userId}`<br />Added `GET /roles/{id}/entitlements`<br />Added `DELETE /roles/{id}/entitlements/{entitlementId}` |
+    | **0.0.1** | Initial dump |
+  version: 0.0.8
+paths:
+  /authentication/providers:
+    get:
+      tags:
+        - authentication
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: Returns the list of supported identity providers.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /authentication:
+    get:
+      tags:
+        - authentication
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: List authentication methods.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/IdentityProviders'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    post:
+      tags:
+        - authentication
+      summary: Register a new authentication method.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentityProvider'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityProvider'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /authentication/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - authentication/{id}
+      summary: Get a single authentication method.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/IdentityProviders'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - authentication/{id}
+      summary: Update an authentication method.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/IdentityProvider'
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    delete:
+      tags:
+        - authentication/{id}
+      summary: Remove an authentication method.
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /users:
+    get:
+      tags:
+        - users
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/FilterParam'
+      summary: Get list of users.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Users'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    post:
+      tags:
+        - users
+      summary: Add a local user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /users/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - users/{id}
+      summary: Get a single user.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Users'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - users/{id}
+      summary: Update a local user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    delete:
+      tags:
+        - users/{id}
+      summary: Remove a local user.
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /users/{id}/groups:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - users/{id}
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: List groups the user is a member of.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Groups'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /users/{id}/roles:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - users/{id}
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: List roles the user is a member of.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Roles'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /users/{id}/entitlements:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - users/{id}
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: List entitlements the user is a member of.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Entitlements'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /groups:
+    get:
+      tags:
+        - groups
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/FilterParam'
+      summary: Get all groups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Groups'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    post:
+      tags:
+        - groups
+      summary: Create a new group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Group'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /groups/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - groups/{id}
+      summary: Get a single user.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Groups'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - groups/{id}
+      summary: Update a group.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Group'
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    delete:
+      tags:
+        - groups/{id}
+      summary: Remove a group.
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /groups/{id}/users:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - groups/{id}
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: Get the users of a group
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Users'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - groups/{id}
+      summary: Update the list of a groups users.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /groups/{id}/users/{userId}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: string
+    delete:
+      tags:
+        - groups/{id}
+      summary: Remove a user from a group
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /roles:
+    get:
+      tags:
+        - roles
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/FilterParam'
+      summary: Get the list of roles.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Roles'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    post:
+      tags:
+        - roles
+      summary: Create a new role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Role'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Role'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /roles/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - roles/{id}
+      summary: Get a single role.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Roles'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - roles/{id}
+      summary: Update a role.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/Role'
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    delete:
+      tags:
+        - roles/{id}
+      summary: Delete a role.
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /roles/{id}/entitlements:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - roles/{id}
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: Get the entitlements of a role
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Entitlements'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /roles/{id}/entitlements/{entitlementId}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: entitlementId
+        in: path
+        required: true
+        schema:
+          type: string
+    delete:
+      tags:
+        - roles/{id}
+      summary: Remove an entitlement from a role
+      responses:
+        '200':
+          description: OK
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /entitlements:
+    get:
+      tags:
+        - entitlements
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/FilterParam'
+      summary: Get the list of entitlements in JSON format.
+      description: The application/json response type will return the JSON authorisation model.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/EntityEntitlements'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /entitlements/raw:
+    get:
+      tags:
+        - entitlements
+      summary: Get the list of entitlements as raw text.
+      description: The text/plain response type will return the raw authorisation model.
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+    put:
+      tags:
+        - entitlements
+      summary: Update the authorisation model.
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              examples: ["...authorization model string"]
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+                examples: ["...authorization model string"]
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+  /resources:
+    get:
+      tags:
+        - resources
+      parameters:
+        - $ref: '#/components/parameters/PaginationSize'
+        - $ref: '#/components/parameters/PaginationPage'
+      summary: Get the list of available resources.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+                  - $ref: '#/components/schemas/Resources'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/default'
+
+components:
+  schemas:
+    IdentityProviders:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityProvider'
+    IdentityProvider:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        enabled:
+          type: boolean
+        redirectUrl:
+          type: string
+        clientID:
+          type: string
+        clientSecret:
+          type: string
+        storeTokens:
+          type: boolean
+        storeTokensReadable:
+          type: boolean
+        acceptsPromptNone:
+          type: boolean
+        disableUserInfo:
+          type: boolean
+        trustEmail:
+          type: boolean
+        accountLinkingOnly:
+          type: boolean
+        syncMode:
+          type: string
+          enum:
+            - import
+        userCount:
+          type: number
+    Users:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+    User:
+      type: object
+      required:
+        - email
+        - source
+        - addedBy
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        joined:
+          type: string
+        lastLogin:
+          type: string
+        source:
+          type: string
+          examples: ["external", "internal"]
+        groups:
+          type: number
+        roles:
+          type: number
+        permissions:
+          type: number
+        addedBy:
+          type: string
+          examples: ["okta"]
+        certificate:
+          type: string
+    Groups:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Group'
+    Group:
+      type: string
+      examples: ["global", "administrator", "viewer"]
+    Roles:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Role'
+    Role:
+      type: string
+      examples: ["global", "administrator", "viewer"]
+    Entity:
+      type: string
+      examples: ["Controller", "Cloud"]
+    Entitlements:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Entitlement"
+    Entitlement:
+      type: string
+      examples: ["read", "destroy", "add-cloud"]
+    EntityEntitlements:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              entity:
+                $ref: "#/components/schemas/Entity"
+              entitlement:
+                $ref: "#/components/schemas/Entitlement"
+    Resources:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resource'
+    Resource:
+      type: object
+      required:
+        - id
+        - name
+        - entity
+        - parent
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          examples: ["aws/eu-west"]
+        entity:
+          $ref: '#/components/schemas/Entity'
+        parent:
+          $ref: '#/components/schemas/Resource'
+    Response:
+      type: object
+      required:
+        - message
+        - status
+        - _meta
+        - _links
+      properties:
+        message:
+          type: string
+        status:
+          type: number
+        _meta:
+          type: object
+          required:
+            - page
+            - size
+            - total
+          properties:
+            page:
+              type: number
+            size:
+              type: number
+            total:
+              type: number
+        _links:
+          type: object
+          required:
+            - next
+          properties:
+            next:
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+  parameters:
+    PaginationSize:
+      in: query
+      name: size
+      schema:
+        type: number
+        minimum: 1
+        maximum: 100
+      description: The number of records to return per response
+    PaginationPage:
+      in: query
+      name: page
+      schema:
+        type: number
+        minimum: 1
+      description: The record offset to return results from
+    FilterParam:
+      in: query
+      name: filter
+      schema:
+        type: string
+      description: A string to filter results by
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Response'
+          example:
+            data: []
+            status: 400
+            message: 'Bad request'
+            _meta:
+              page: 0
+              size: 0
+              total: 0
+            _links:
+              next:
+                href: ""
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Response'
+          example:
+            data: []
+            status: 401
+            message: 'Unauthorized'
+            _meta:
+              page: 0
+              size: 0
+              total: 0
+            _links:
+              next:
+                href: ""
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Response'
+          example:
+            data: []
+            status: 404
+            message: 'Not found'
+            _meta:
+              page: 0
+              size: 0
+              total: 0
+            _links:
+              next:
+                href: ""
+    default:
+      description: Unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Response'
+          example:
+            data: []
+            status: 500
+            message: 'Unexpected error'
+            _meta:
+              page: 0
+              size: 0
+              total: 0
+            _links:
+              next:
+                href: ""

--- a/src/api/api.schemas.ts
+++ b/src/api/api.schemas.ts
@@ -29,48 +29,7 @@ export type GetResourcesParams = {
   page?: PaginationPageParameter;
 };
 
-export type GetEntitlementsParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
-  /**
-   * A string to filter results by
-   */
-  filter?: FilterParamParameter;
-};
-
 export type GetRolesIdEntitlementsParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
-};
-
-export type GetRolesParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
-  /**
-   * A string to filter results by
-   */
-  filter?: FilterParamParameter;
-};
-
-export type GetGroupsIdUsersParams = {
   /**
    * The number of records to return per response
    */
@@ -83,11 +42,20 @@ export type GetGroupsIdUsersParams = {
 
 export type GetGroupsId200 = Response & Groups;
 
-export type GetGroups200 = Response & Groups;
-
-export type GetUsersIdEntitlements200 = Response & Entitlements;
-
-export type GetUsersIdRoles200 = Response & Roles;
+export type GetGroupsParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
+  /**
+   * A string to filter results by
+   */
+  filter?: FilterParamParameter;
+};
 
 export type GetUsersIdRolesParams = {
   /**
@@ -136,7 +104,7 @@ export type PaginationPageParameter = number;
  */
 export type PaginationSizeParameter = number;
 
-export type GetGroupsParams = {
+export type GetEntitlementsParams = {
   /**
    * The number of records to return per response
    */
@@ -149,6 +117,32 @@ export type GetGroupsParams = {
    * A string to filter results by
    */
   filter?: FilterParamParameter;
+};
+
+export type GetRolesParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
+  /**
+   * A string to filter results by
+   */
+  filter?: FilterParamParameter;
+};
+
+export type GetGroupsIdUsersParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
 };
 
 export type GetUsersIdEntitlementsParams = {
@@ -200,42 +194,6 @@ export type GetAuthenticationProvidersParams = {
 };
 
 /**
- * Not found
- */
-export type NotFoundResponse = Response;
-
-export type ResponseDataItem = { [key: string]: any };
-
-export type _ResponseMeta = {
-  page: number;
-  size: number;
-  total: number;
-};
-
-export interface Response {
-  _links: _ResponseLinks;
-  _meta: _ResponseMeta;
-  data: ResponseDataItem[];
-  message: string;
-  status: number;
-}
-
-export type GetResources200 = Response & Resources;
-
-export type GetRolesIdEntitlements200 = Response & Entitlements;
-
-export type GetRolesId200 = Response & Roles;
-
-export type GetRoles200 = Response & Roles;
-
-export type GetGroupsIdUsers200 = Response & Users;
-
-/**
- * Unexpected error
- */
-export type DefaultResponse = Response;
-
-/**
  * Unauthorized
  */
 export type UnauthorizedResponse = Response;
@@ -245,6 +203,12 @@ export type UnauthorizedResponse = Response;
  */
 export type BadRequestResponse = Response;
 
+export type _ResponseMeta = {
+  page: number;
+  size: number;
+  total: number;
+};
+
 export type _ResponseLinksNext = {
   href: string;
 };
@@ -252,6 +216,41 @@ export type _ResponseLinksNext = {
 export type _ResponseLinks = {
   next: _ResponseLinksNext;
 };
+
+export interface Response {
+  _links: _ResponseLinks;
+  _meta: _ResponseMeta;
+  message: string;
+  status: number;
+}
+
+export type GetResources200 = Response & Resources;
+
+export type GetEntitlements200 = Response & EntityEntitlements;
+
+export type GetRolesIdEntitlements200 = Response & Entitlements;
+
+export type GetRolesId200 = Response & Roles;
+
+export type GetRoles200 = Response & Roles;
+
+export type GetGroupsIdUsers200 = Response & Users;
+
+export type GetGroups200 = Response & Groups;
+
+export type GetUsersIdEntitlements200 = Response & Entitlements;
+
+export type GetUsersIdRoles200 = Response & Roles;
+
+/**
+ * Unexpected error
+ */
+export type DefaultResponse = Response;
+
+/**
+ * Not found
+ */
+export type NotFoundResponse = Response;
 
 export interface Resource {
   entity: Entity;
@@ -275,34 +274,19 @@ export interface EntityEntitlements {
   data: EntityEntitlementsDataItem[];
 }
 
-export type GetEntitlements200 = Response & EntityEntitlements;
-
 export interface Entitlements {
   data: Entitlement[];
 }
 
 export type Entity = string;
 
-export type RoleEntitlementsItem = {
-  entitlement?: string;
-  entity?: Entity;
-  resource?: string;
-};
-
-export interface Role {
-  entitlements?: RoleEntitlementsItem[];
-  id?: string;
-  name: string;
-}
+export type Role = string;
 
 export interface Roles {
   data: Role[];
 }
 
-export interface Group {
-  id?: string;
-  name: string;
-}
+export type Group = string;
 
 export interface Groups {
   data: Group[];

--- a/src/api/authentication-id/authentication-id.msw.ts
+++ b/src/api/authentication-id/authentication-id.msw.ts
@@ -36,13 +36,53 @@ export const getGetAuthenticationIdResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    acceptsPromptNone: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    accountLinkingOnly: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    clientID: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    clientSecret: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    disableUserInfo: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    enabled: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    name: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    redirectUrl: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    storeTokens: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    storeTokensReadable: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    syncMode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(["import"] as const),
+      undefined,
+    ]),
+    trustEmail: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    userCount: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/api/authentication/authentication.msw.ts
+++ b/src/api/authentication/authentication.msw.ts
@@ -40,10 +40,6 @@ export const getGetAuthenticationProvidersResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
@@ -62,13 +58,53 @@ export const getGetAuthenticationResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    acceptsPromptNone: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    accountLinkingOnly: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    clientID: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    clientSecret: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    disableUserInfo: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    enabled: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    name: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    redirectUrl: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    storeTokens: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    storeTokensReadable: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    syncMode: faker.helpers.arrayElement([
+      faker.helpers.arrayElement(["import"] as const),
+      undefined,
+    ]),
+    trustEmail: faker.helpers.arrayElement([
+      faker.datatype.boolean(),
+      undefined,
+    ]),
+    userCount: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/api/entitlements/entitlements.msw.ts
+++ b/src/api/entitlements/entitlements.msw.ts
@@ -36,13 +36,17 @@ export const getGetEntitlementsResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    entitlement: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    entity: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/api/groups-id/groups-id.msw.ts
+++ b/src/api/groups-id/groups-id.msw.ts
@@ -36,13 +36,13 @@ export const getGetGroupsIdResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
@@ -59,13 +59,36 @@ export const getGetGroupsIdUsersResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    addedBy: faker.word.sample(),
+    certificate: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    email: faker.word.sample(),
+    firstName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    groups: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    joined: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastLogin: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    permissions: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    roles: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    source: faker.word.sample(),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/api/groups/groups.msw.ts
+++ b/src/api/groups/groups.msw.ts
@@ -36,23 +36,17 @@ export const getGetGroupsResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
-export const getPostGroupsResponseMock = (
-  overrideResponse: any = {},
-): Group => ({
-  id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
-  name: faker.word.sample(),
-  ...overrideResponse,
-});
+export const getPostGroupsResponseMock = (): Group => faker.word.sample();
 
 export const getGetGroupsMockHandler = (overrideResponse?: GetGroups200) => {
   return http.get("*/groups", async () => {

--- a/src/api/resources/resources.msw.ts
+++ b/src/api/resources/resources.msw.ts
@@ -36,13 +36,18 @@ export const getGetResourcesResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    entity: faker.word.sample(),
+    id: faker.word.sample(),
+    name: faker.word.sample(),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/api/roles-id/roles-id.msw.ts
+++ b/src/api/roles-id/roles-id.msw.ts
@@ -36,13 +36,13 @@ export const getGetRolesIdResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
@@ -59,13 +59,13 @@ export const getGetRolesIdEntitlementsResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 

--- a/src/api/roles/roles.msw.ts
+++ b/src/api/roles/roles.msw.ts
@@ -36,40 +36,21 @@ export const getGetRolesResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
-export const getPostRolesResponseMock = (overrideResponse: any = {}): Role[] =>
+export const getPostRolesResponseMock = (): Role[] =>
   Array.from(
     { length: faker.number.int({ min: 1, max: 10 }) },
     (_, i) => i + 1,
-  ).map(() => ({
-    entitlements: faker.helpers.arrayElement([
-      Array.from(
-        { length: faker.number.int({ min: 1, max: 10 }) },
-        (_, i) => i + 1,
-      ).map(() => ({
-        entitlement: faker.helpers.arrayElement([
-          faker.word.sample(),
-          undefined,
-        ]),
-        entity: faker.helpers.arrayElement([faker.word.sample(), undefined]),
-        resource: faker.helpers.arrayElement([faker.word.sample(), undefined]),
-        ...overrideResponse,
-      })),
-      undefined,
-    ]),
-    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
-    name: faker.word.sample(),
-    ...overrideResponse,
-  }));
+  ).map(() => faker.word.sample());
 
 export const getGetRolesMockHandler = (overrideResponse?: GetRoles200) => {
   return http.get("*/roles", async () => {

--- a/src/api/users-id/users-id.msw.ts
+++ b/src/api/users-id/users-id.msw.ts
@@ -41,13 +41,36 @@ export const getGetUsersIdResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    addedBy: faker.word.sample(),
+    certificate: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    email: faker.word.sample(),
+    firstName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    groups: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    joined: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastLogin: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    permissions: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    roles: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    source: faker.word.sample(),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 
@@ -64,13 +87,13 @@ export const getGetUsersIdGroupsResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
@@ -87,13 +110,13 @@ export const getGetUsersIdRolesResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 
@@ -110,13 +133,13 @@ export const getGetUsersIdEntitlementsResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => faker.word.sample()),
   ...overrideResponse,
 });
 

--- a/src/api/users/users.msw.ts
+++ b/src/api/users/users.msw.ts
@@ -36,13 +36,36 @@ export const getGetUsersResponseMock = (
     total: faker.number.int({ min: undefined, max: undefined }),
     ...overrideResponse,
   },
-  data: Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => ({})),
   message: faker.word.sample(),
   status: faker.number.int({ min: undefined, max: undefined }),
   ...overrideResponse,
+  data: Array.from(
+    { length: faker.number.int({ min: 1, max: 10 }) },
+    (_, i) => i + 1,
+  ).map(() => ({
+    addedBy: faker.word.sample(),
+    certificate: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    email: faker.word.sample(),
+    firstName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    groups: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    id: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    joined: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastLogin: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    lastName: faker.helpers.arrayElement([faker.word.sample(), undefined]),
+    permissions: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    roles: faker.helpers.arrayElement([
+      faker.number.int({ min: undefined, max: undefined }),
+      undefined,
+    ]),
+    source: faker.word.sample(),
+    ...overrideResponse,
+  })),
   ...overrideResponse,
 });
 

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -3,6 +3,8 @@ import axios from "axios";
 import { Route, Routes } from "react-router-dom";
 
 import Panel from "components/Panel";
+import Groups from "components/pages/Groups";
+import Roles from "components/pages/Roles";
 import Users from "components/pages/Users";
 import urls from "urls";
 
@@ -40,12 +42,12 @@ const ReBACAdmin = ({ apiURL }: Props) => {
           path={urls.entitlements}
           element={<Panel title="Entitlements" />}
         />
-        <Route path={urls.groups.index} element={<Panel title="Groups" />} />
+        <Route path={urls.groups.index} element={<Groups />} />
         <Route
           path={urls.resources.index}
           element={<Panel title="Resources" />}
         />
-        <Route path={urls.roles.index} element={<Panel title="Roles" />} />
+        <Route path={urls.roles.index} element={<Roles />} />
         <Route path={urls.users.index} element={<Users />} />
       </Routes>
     </QueryClientProvider>

--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -1,0 +1,77 @@
+import { act, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupServer } from "msw/node";
+
+import {
+  getGetGroupsMockHandler,
+  getGetGroupsResponseMock,
+} from "api/groups/groups.msw";
+import { getGetGroupsErrorMockHandler } from "mocks/groups";
+import { renderComponent } from "test/utils";
+
+import Groups from "./Groups";
+import { Label as GroupsLabel } from "./types";
+
+const mockGroupsData = getGetGroupsResponseMock({
+  data: ["global", "administrator", "viewer"],
+});
+const mockApiServer = setupServer(getGetGroupsMockHandler(mockGroupsData));
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+test("should display spinner on mount", () => {
+  renderComponent(<Groups />);
+  expect(screen.getByText(GroupsLabel.FETCHING_GROUPS)).toBeInTheDocument();
+});
+
+test("should display correct group data after fetching groups", async () => {
+  renderComponent(<Groups />);
+  const columnHeaders = await screen.findAllByRole("columnheader");
+  expect(columnHeaders).toHaveLength(1);
+  const rows = screen.getAllByRole("row");
+  // The first row contains the column header and the next 3 rows contain
+  // group data.
+  expect(rows).toHaveLength(4);
+  expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent("global");
+  expect(within(rows[2]).getAllByRole("cell")[0]).toHaveTextContent(
+    "administrator",
+  );
+  expect(within(rows[3]).getAllByRole("cell")[0]).toHaveTextContent("viewer");
+});
+
+test("should display no groups data when no groups are available", async () => {
+  mockApiServer.use(
+    getGetGroupsMockHandler(getGetGroupsResponseMock({ data: [] })),
+  );
+  renderComponent(<Groups />);
+  expect(await screen.findByText(GroupsLabel.NO_GROUPS)).toBeInTheDocument();
+});
+
+test("should display error notification and refetch data", async () => {
+  mockApiServer.use(getGetGroupsErrorMockHandler());
+  renderComponent(<Groups />);
+  const groupsErrorNotification = await screen.findByText(
+    GroupsLabel.FETCHING_GROUPS_ERROR,
+    { exact: false },
+  );
+  expect(groupsErrorNotification.childElementCount).toBe(1);
+  const refetchButton = groupsErrorNotification.children[0];
+  mockApiServer.use(getGetGroupsMockHandler(mockGroupsData));
+  expect(refetchButton).toHaveTextContent("refetch");
+  await act(() => userEvent.click(refetchButton));
+  expect(
+    await screen.findByText(GroupsLabel.FETCHING_GROUPS),
+  ).toBeInTheDocument();
+  const rows = await screen.findAllByRole("row");
+  expect(rows).toHaveLength(4);
+});

--- a/src/components/pages/Groups/Groups.tsx
+++ b/src/components/pages/Groups/Groups.tsx
@@ -1,0 +1,57 @@
+import { ModularTable, Spinner } from "@canonical/react-components";
+import { useMemo, type JSX } from "react";
+import type { Column } from "react-table";
+
+import { useGetGroups } from "api/groups/groups";
+import Content from "components/Content";
+import ErrorNotification from "components/ErrorNotification";
+
+import { Label } from "./types";
+
+const COLUMN_DATA: Column[] = [
+  {
+    Header: "group name",
+    accessor: "groupName",
+  },
+];
+
+const Groups = () => {
+  const { data, isFetching, isError, error, refetch } = useGetGroups();
+
+  const tableData = useMemo(() => {
+    const groups = data?.data.data;
+    if (!groups) {
+      return [];
+    }
+    const tableData = groups.map((group) => ({
+      groupName: group,
+    }));
+    return tableData;
+  }, [data]);
+
+  const generateContent = (): JSX.Element => {
+    if (isFetching) {
+      return <Spinner text={Label.FETCHING_GROUPS} />;
+    } else if (isError) {
+      return (
+        <ErrorNotification
+          message={Label.FETCHING_GROUPS_ERROR}
+          error={error?.message ?? ""}
+          onRefetch={() => void refetch()}
+        />
+      );
+    } else {
+      return (
+        <ModularTable
+          columns={COLUMN_DATA}
+          data={tableData}
+          emptyMsg={Label.NO_GROUPS}
+        />
+      );
+    }
+  };
+
+  return <Content title="Groups">{generateContent()}</Content>;
+};
+
+export default Groups;

--- a/src/components/pages/Groups/index.ts
+++ b/src/components/pages/Groups/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Groups";
+export * from "./types";

--- a/src/components/pages/Groups/types.ts
+++ b/src/components/pages/Groups/types.ts
@@ -1,0 +1,5 @@
+export enum Label {
+  FETCHING_GROUPS = "Fetching groups data...",
+  FETCHING_GROUPS_ERROR = "Couldn't fetch group data.",
+  NO_GROUPS = "No groups found!",
+}

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -1,0 +1,77 @@
+import { act, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupServer } from "msw/node";
+
+import {
+  getGetRolesMockHandler,
+  getGetRolesResponseMock,
+} from "api/roles/roles.msw";
+import { getGetRolesErrorMockHandler } from "mocks/roles";
+import { renderComponent } from "test/utils";
+
+import Roles from "./Roles";
+import { Label as RolesLabel } from "./types";
+
+const mockRolesData = getGetRolesResponseMock({
+  data: ["global", "administrator", "viewer"],
+});
+const mockApiServer = setupServer(getGetRolesMockHandler(mockRolesData));
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+test("should display spinner on mount", () => {
+  renderComponent(<Roles />);
+  expect(screen.getByText(RolesLabel.FETCHING_ROLES)).toBeInTheDocument();
+});
+
+test("should display correct role data after fetching roles", async () => {
+  renderComponent(<Roles />);
+  const columnHeaders = await screen.findAllByRole("columnheader");
+  expect(columnHeaders).toHaveLength(1);
+  const rows = screen.getAllByRole("row");
+  // The first row contains the column header and the next 3 rows contain
+  // role data.
+  expect(rows).toHaveLength(4);
+  expect(within(rows[1]).getAllByRole("cell")[0]).toHaveTextContent("global");
+  expect(within(rows[2]).getAllByRole("cell")[0]).toHaveTextContent(
+    "administrator",
+  );
+  expect(within(rows[3]).getAllByRole("cell")[0]).toHaveTextContent("viewer");
+});
+
+test("should display no roles data when no roles are available", async () => {
+  mockApiServer.use(
+    getGetRolesMockHandler(getGetRolesResponseMock({ data: [] })),
+  );
+  renderComponent(<Roles />);
+  expect(await screen.findByText(RolesLabel.NO_ROLES)).toBeInTheDocument();
+});
+
+test("should display error notification and refetch data", async () => {
+  mockApiServer.use(getGetRolesErrorMockHandler());
+  renderComponent(<Roles />);
+  const rolesErrorNotification = await screen.findByText(
+    RolesLabel.FETCHING_ROLES_ERROR,
+    { exact: false },
+  );
+  expect(rolesErrorNotification.childElementCount).toBe(1);
+  const refetchButton = rolesErrorNotification.children[0];
+  mockApiServer.use(getGetRolesMockHandler(mockRolesData));
+  expect(refetchButton).toHaveTextContent("refetch");
+  await act(() => userEvent.click(refetchButton));
+  expect(
+    await screen.findByText(RolesLabel.FETCHING_ROLES),
+  ).toBeInTheDocument();
+  const rows = await screen.findAllByRole("row");
+  expect(rows).toHaveLength(4);
+});

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -1,0 +1,57 @@
+import { ModularTable, Spinner } from "@canonical/react-components";
+import { useMemo, type JSX } from "react";
+import type { Column } from "react-table";
+
+import { useGetRoles } from "api/roles/roles";
+import Content from "components/Content";
+import ErrorNotification from "components/ErrorNotification";
+
+import { Label } from "./types";
+
+const COLUMN_DATA: Column[] = [
+  {
+    Header: "role name",
+    accessor: "roleName",
+  },
+];
+
+const Roles = () => {
+  const { data, isFetching, isError, error, refetch } = useGetRoles();
+
+  const tableData = useMemo(() => {
+    const roles = data?.data.data;
+    if (!roles) {
+      return [];
+    }
+    const tableData = roles.map((role) => ({
+      roleName: role,
+    }));
+    return tableData;
+  }, [data]);
+
+  const generateContent = (): JSX.Element => {
+    if (isFetching) {
+      return <Spinner text={Label.FETCHING_ROLES} />;
+    } else if (isError) {
+      return (
+        <ErrorNotification
+          message={Label.FETCHING_ROLES_ERROR}
+          error={error?.message ?? ""}
+          onRefetch={() => void refetch()}
+        />
+      );
+    } else {
+      return (
+        <ModularTable
+          columns={COLUMN_DATA}
+          data={tableData}
+          emptyMsg={Label.NO_ROLES}
+        />
+      );
+    }
+  };
+
+  return <Content title="Roles">{generateContent()}</Content>;
+};
+
+export default Roles;

--- a/src/components/pages/Roles/index.ts
+++ b/src/components/pages/Roles/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Roles";
+export * from "./types";

--- a/src/components/pages/Roles/types.ts
+++ b/src/components/pages/Roles/types.ts
@@ -1,0 +1,5 @@
+export enum Label {
+  FETCHING_ROLES = "Fetching roles data...",
+  FETCHING_ROLES_ERROR = "Couldn't fetch role data.",
+  NO_ROLES = "No roles found!",
+}

--- a/src/components/pages/Users/Users.tsx
+++ b/src/components/pages/Users/Users.tsx
@@ -63,7 +63,6 @@ const Users = () => {
     } else {
       return (
         <ModularTable
-          className="audit-logs-table"
           columns={COLUMN_DATA}
           data={tableData}
           emptyMsg={Label.NO_USERS}

--- a/src/mocks/groups.ts
+++ b/src/mocks/groups.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, delay, http } from "msw";
+
+import { Endpoint } from "types/api";
+
+export const getGetGroupsErrorMockHandler = (status: number = 404) => {
+  return http.get(`*${Endpoint.GROUPS}`, async () => {
+    await delay(Number(import.meta.env.VITE_MOCK_API_DELAY));
+    return new HttpResponse(undefined, {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+};

--- a/src/mocks/roles.ts
+++ b/src/mocks/roles.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, delay, http } from "msw";
+
+import { Endpoint } from "types/api";
+
+export const getGetRolesErrorMockHandler = (status: number = 404) => {
+  return http.get(`*${Endpoint.ROLES}`, async () => {
+    await delay(Number(import.meta.env.VITE_MOCK_API_DELAY));
+    return new HttpResponse(undefined, {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  });
+};


### PR DESCRIPTION
## Done

- Set up views for groups and roles.
- Modify the responses for groups and roles in `openapi.yaml` to be consistent with [identity-platform-admin-ui](https://github.com/canonical/identity-platform-admin-ui).
- Remove `openapi.yaml` from `.gitignore`.
- Regenerate api files with `Orval`.

## Details

- https://warthogs.atlassian.net/browse/WD-10024