### PR TITLE
WD-10055 - fix: make CI work for admin-service-api

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - admin-service-api
   pull_request:
     branches:
-      - main
+      - admin-service-api
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - main
+      - admin-service-api
   pull_request:
     branches:
-      - main
+      - admin-service-api
 jobs:
   test:
     name: Test


### PR DESCRIPTION
## Done

- Make CI work for `admin-service-api` branch.

## Details

- https://warthogs.atlassian.net/browse/WD-10055