### PR TITLE
WD-10180 - feature: add panel for creating roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Inside your main CSS file add the following:
 
 The following props can be provided to the `ReBACAdmin` component to configure the admin.
 
-| Prop   | Description                                                                          | Examples                       |
-| :----- | :----------------------------------------------------------------------------------- | :----------------------------- |
-| apiURL | The absolute URL of the ReBAC API, including domain if the API is hosted externally. | http://example.com/api/, /api/ |
+| Prop         | Description                                                                          | Examples                       |
+| :----------- | :----------------------------------------------------------------------------------- | :----------------------------- |
+| apiURL       | The absolute URL of the ReBAC API, including domain if the API is hosted externally. | http://example.com/api/, /api/ |
+| asidePanelId | The element ID to use to render aside panels into. Should not begin with "#".        | app-aside                      |
+| authToken    | The base64 encoded user id for the authenticated user.                               | VGhpcyBpcyB5b3VyIHByaXplIQ==   |
 
 ## Navigation
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -153,7 +153,9 @@ const App = () => {
               </Row>
             </Form>
           </AppAside>
-        ) : null
+        ) : (
+          <aside id="aside-panel" />
+        )
       }
       status={
         <Button

--- a/demo/src/main.tsx
+++ b/demo/src/main.tsx
@@ -21,7 +21,13 @@ const defferRender = async () => {
   return mockApiWorker.start();
 };
 
-const admin = () => <ReBACAdmin apiURL={import.meta.env.VITE_DEMO_API_URL} />;
+const admin = () => (
+  <ReBACAdmin
+    apiURL={import.meta.env.VITE_DEMO_API_URL}
+    asidePanelId="aside-panel"
+    authToken={import.meta.env.VITE_DEMO_AUTH_TOKEN}
+  />
+);
 
 const router = createBrowserRouter([
   {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -594,16 +594,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Role'
+              $ref: '#/components/schemas/RoleObject'
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Role'
+                $ref: '#/components/schemas/Response'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -946,6 +944,14 @@ components:
     Role:
       type: string
       examples: ["global", "administrator", "viewer"]
+    RoleObject:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+      examples: [{ id: "global" }, { id: "administrator" }, { id: "viewer" }]
     Entity:
       type: string
       examples: ["Controller", "Cloud"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -596,7 +596,7 @@ paths:
             schema:
               $ref: '#/components/schemas/RoleObject'
       responses:
-        '200':
+        '201':
           description: OK
           content:
             application/json:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "git@github.com:canonical/rebac-admin.git",
   "author": "Canonical Webteam",
   "license": "AGPL-3.0",
-  "private": false,
   "packageManager": "yarn@4.1.0",
   "type": "module",
   "files": [
@@ -61,7 +60,9 @@
   },
   "dependencies": {
     "classnames": "2.5.1",
-    "clone-deep": "4.0.1"
+    "clone-deep": "4.0.1",
+    "react-hot-toast": "2.4.1",
+    "react-useportal": "1.0.19"
   },
   "devDependencies": {
     "@canonical/react-components": "0.51.1",

--- a/src/api/api.schemas.ts
+++ b/src/api/api.schemas.ts
@@ -29,7 +29,9 @@ export type GetResourcesParams = {
   page?: PaginationPageParameter;
 };
 
-export type GetRolesIdEntitlementsParams = {
+export type GetRolesId200 = Response & Roles;
+
+export type GetGroupsIdUsersParams = {
   /**
    * The number of records to return per response
    */
@@ -39,8 +41,6 @@ export type GetRolesIdEntitlementsParams = {
    */
   page?: PaginationPageParameter;
 };
-
-export type GetGroupsId200 = Response & Groups;
 
 export type GetGroupsParams = {
   /**
@@ -119,6 +119,17 @@ export type GetEntitlementsParams = {
   filter?: FilterParamParameter;
 };
 
+export type GetRolesIdEntitlementsParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
+};
+
 export type GetRolesParams = {
   /**
    * The number of records to return per response
@@ -132,17 +143,6 @@ export type GetRolesParams = {
    * A string to filter results by
    */
   filter?: FilterParamParameter;
-};
-
-export type GetGroupsIdUsersParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
 };
 
 export type GetUsersIdEntitlementsParams = {
@@ -194,6 +194,11 @@ export type GetAuthenticationProvidersParams = {
 };
 
 /**
+ * Unexpected error
+ */
+export type DefaultResponse = Response;
+
+/**
  * Unauthorized
  */
 export type UnauthorizedResponse = Response;
@@ -228,24 +233,17 @@ export type GetResources200 = Response & Resources;
 
 export type GetEntitlements200 = Response & EntityEntitlements;
 
-export type GetRolesIdEntitlements200 = Response & Entitlements;
-
-export type GetRolesId200 = Response & Roles;
-
 export type GetRoles200 = Response & Roles;
 
 export type GetGroupsIdUsers200 = Response & Users;
+
+export type GetGroupsId200 = Response & Groups;
 
 export type GetGroups200 = Response & Groups;
 
 export type GetUsersIdEntitlements200 = Response & Entitlements;
 
 export type GetUsersIdRoles200 = Response & Roles;
-
-/**
- * Unexpected error
- */
-export type DefaultResponse = Response;
 
 /**
  * Not found
@@ -278,7 +276,13 @@ export interface Entitlements {
   data: Entitlement[];
 }
 
+export type GetRolesIdEntitlements200 = Response & Entitlements;
+
 export type Entity = string;
+
+export interface RoleObject {
+  id: string;
+}
 
 export type Role = string;
 

--- a/src/api/roles/roles.msw.ts
+++ b/src/api/roles/roles.msw.ts
@@ -21,7 +21,7 @@
 import { faker } from "@faker-js/faker";
 import { HttpResponse, delay, http } from "msw";
 
-import type { GetRoles200, Role } from "../api.schemas";
+import type { GetRoles200, Response } from "../api.schemas";
 
 export const getGetRolesResponseMock = (
   overrideResponse: any = {},
@@ -46,11 +46,23 @@ export const getGetRolesResponseMock = (
   ...overrideResponse,
 });
 
-export const getPostRolesResponseMock = (): Role[] =>
-  Array.from(
-    { length: faker.number.int({ min: 1, max: 10 }) },
-    (_, i) => i + 1,
-  ).map(() => faker.word.sample());
+export const getPostRolesResponseMock = (
+  overrideResponse: any = {},
+): Response => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
 
 export const getGetRolesMockHandler = (overrideResponse?: GetRoles200) => {
   return http.get("*/roles", async () => {
@@ -69,7 +81,7 @@ export const getGetRolesMockHandler = (overrideResponse?: GetRoles200) => {
   });
 };
 
-export const getPostRolesMockHandler = (overrideResponse?: Role[]) => {
+export const getPostRolesMockHandler = (overrideResponse?: Response) => {
   return http.post("*/roles", async () => {
     await delay(900);
     return new HttpResponse(

--- a/src/api/roles/roles.ts
+++ b/src/api/roles/roles.ts
@@ -36,7 +36,8 @@ import type {
   GetRoles200,
   GetRolesParams,
   NotFoundResponse,
-  Role,
+  Response,
+  RoleObject,
   UnauthorizedResponse,
 } from "../api.schemas";
 
@@ -131,10 +132,10 @@ export const useGetRoles = <
  * @summary Create a new role
  */
 export const postRoles = (
-  role: Role,
+  roleObject: RoleObject,
   options?: AxiosRequestConfig,
-): Promise<AxiosResponse<Role[]>> => {
-  return axios.post(`/roles`, role, options);
+): Promise<AxiosResponse<Response>> => {
+  return axios.post(`/roles`, roleObject, options);
 };
 
 export const getPostRolesMutationOptions = <
@@ -149,21 +150,21 @@ export const getPostRolesMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof postRoles>>,
     TError,
-    { data: Role },
+    { data: RoleObject },
     TContext
   >;
   axios?: AxiosRequestConfig;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof postRoles>>,
   TError,
-  { data: Role },
+  { data: RoleObject },
   TContext
 > => {
   const { mutation: mutationOptions, axios: axiosOptions } = options ?? {};
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof postRoles>>,
-    { data: Role }
+    { data: RoleObject }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -176,7 +177,7 @@ export const getPostRolesMutationOptions = <
 export type PostRolesMutationResult = NonNullable<
   Awaited<ReturnType<typeof postRoles>>
 >;
-export type PostRolesMutationBody = Role;
+export type PostRolesMutationBody = RoleObject;
 export type PostRolesMutationError = AxiosError<
   BadRequestResponse | UnauthorizedResponse | NotFoundResponse | DefaultResponse
 >;
@@ -196,7 +197,7 @@ export const usePostRoles = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof postRoles>>,
     TError,
-    { data: Role },
+    { data: RoleObject },
     TContext
   >;
   axios?: AxiosRequestConfig;

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -6,11 +6,12 @@ import Panel from "components/Panel";
 import "./_content.scss";
 
 type Props = {
+  controls?: ReactNode;
   title: ReactNode;
 } & PropsWithChildren;
 
-const Content = ({ children, title }: Props): JSX.Element => (
-  <Panel title={title}>
+const Content = ({ children, controls, title }: Props): JSX.Element => (
+  <Panel controls={controls} title={title}>
     <div className="l-content">{children}</div>
   </Panel>
 );

--- a/src/components/PanelForm/PanelForm.test.tsx
+++ b/src/components/PanelForm/PanelForm.test.tsx
@@ -1,0 +1,121 @@
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { ReBACAdminContext } from "context/ReBACAdminContext";
+import { hasNotification, renderComponent } from "test/utils";
+
+import PanelForm from "./PanelForm";
+import { Label } from "./types";
+
+test("can display contents", async () => {
+  renderComponent(
+    <PanelForm<{ name: string }>
+      close={vi.fn()}
+      entity="role"
+      initialValues={{ name: "" }}
+      onSubmit={vi.fn()}
+    >
+      Form content
+    </PanelForm>,
+  );
+  expect(screen.getByText("Form content")).toBeInTheDocument();
+});
+
+test("can display add state", async () => {
+  renderComponent(
+    <PanelForm<{ name: string }>
+      close={vi.fn()}
+      entity="role"
+      initialValues={{ name: "" }}
+      onSubmit={vi.fn()}
+    >
+      Form content
+    </PanelForm>,
+  );
+  expect(
+    screen.getByRole("heading", { name: "Create role" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Create role" }),
+  ).toBeInTheDocument();
+});
+
+test("can display edit state", async () => {
+  renderComponent(
+    <PanelForm<{ name: string }>
+      close={vi.fn()}
+      entity="role"
+      initialValues={{ name: "" }}
+      isEditing
+      onSubmit={vi.fn()}
+    >
+      Form content
+    </PanelForm>,
+  );
+  expect(
+    screen.getByRole("heading", { name: "Edit role" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Update role" }),
+  ).toBeInTheDocument();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("can display errors", async () => {
+  renderComponent(
+    <PanelForm<{ name: string }>
+      close={vi.fn()}
+      entity="role"
+      error="Uh oh!"
+      initialValues={{ name: "" }}
+      onSubmit={vi.fn()}
+    >
+      Form content
+    </PanelForm>,
+  );
+  await hasNotification("Uh oh!");
+});
+
+test("can cancel", async () => {
+  const close = vi.fn();
+  renderComponent(
+    <PanelForm<{ name: string }>
+      close={close}
+      entity="role"
+      initialValues={{ name: "" }}
+      onSubmit={vi.fn()}
+    >
+      Form content
+    </PanelForm>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: Label.CANCEL })),
+  );
+  expect(close).toHaveBeenCalled();
+});
+
+test("can submit the form", async () => {
+  const onSubmit = vi.fn();
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
+      <div id="aside-panel"></div>
+      <PanelForm<{ name: string }>
+        close={vi.fn()}
+        entity="role"
+        initialValues={{ name: "" }}
+        onSubmit={onSubmit}
+      >
+        Form content
+      </PanelForm>
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create role" }),
+      ),
+  );
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/src/components/PanelForm/PanelForm.tsx
+++ b/src/components/PanelForm/PanelForm.tsx
@@ -1,0 +1,72 @@
+import {
+  ActionButton,
+  Button,
+  Col,
+  Notification,
+  NotificationSeverity,
+  Row,
+} from "@canonical/react-components";
+import type { FormikValues } from "formik";
+import { Form, Formik } from "formik";
+
+import { Label, type Props } from "./types";
+
+const PanelForm = <F extends FormikValues>({
+  children,
+  close,
+  entity,
+  error,
+  isEditing,
+  isSaving,
+  ...props
+}: Props<F>) => {
+  // This component does not use the Panel component as Vanilla requires a strict
+  // element hierarchy that can't be achieved using the normal components in
+  // conjunction with portals.
+  return (
+    <>
+      <div className="p-panel__header">
+        <h4 className="p-panel__title">
+          {isEditing ? `Edit ${entity}` : `Create ${entity}`}
+        </h4>
+      </div>
+      <div className="p-panel__content">
+        {error ? (
+          <Row>
+            <Col size={12}>
+              <Notification severity={NotificationSeverity.NEGATIVE}>
+                {error}
+              </Notification>
+            </Col>
+          </Row>
+        ) : null}
+        <Formik<F> {...props}>
+          <Form>
+            <Row>
+              <Col size={12}>{children}</Col>
+            </Row>
+            <Row className="u-align--right">
+              <Col size={12}>
+                <hr />
+              </Col>
+              <Col size={12}>
+                <Button appearance="base" onClick={close} type="button">
+                  {Label.CANCEL}
+                </Button>
+                <ActionButton
+                  appearance="positive"
+                  loading={isSaving}
+                  type="submit"
+                >
+                  {isEditing ? `Update ${entity}` : `Create ${entity}`}
+                </ActionButton>
+              </Col>
+            </Row>
+          </Form>
+        </Formik>
+      </div>
+    </>
+  );
+};
+
+export default PanelForm;

--- a/src/components/PanelForm/index.ts
+++ b/src/components/PanelForm/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PanelForm";
+export * from "./types";

--- a/src/components/PanelForm/types.ts
+++ b/src/components/PanelForm/types.ts
@@ -1,0 +1,15 @@
+import type { FormikConfig, FormikValues } from "formik";
+import type { PropsWithChildren } from "react";
+
+export type Props<F extends FormikValues> = {
+  close: () => void;
+  entity: string;
+  error?: string | null;
+  isEditing?: boolean;
+  isSaving?: boolean;
+} & PropsWithChildren &
+  Omit<FormikConfig<F>, "children">;
+
+export enum Label {
+  CANCEL = "Cancel",
+}

--- a/src/components/ReBACAdmin/ReBACAdmin.test.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.test.tsx
@@ -16,6 +16,14 @@ test("the api URL can be configured", () => {
   expect(axios.defaults.baseURL).toBe(apiURL);
 });
 
+test("the auth token can be configured", () => {
+  const apiURL = "http://example.com/api";
+  renderComponent(<ReBACAdmin apiURL={apiURL} authToken="U3VwZXIgc2VjcmV0" />);
+  expect(axios.defaults.headers.common["X-Authorization"]).toBe(
+    "U3VwZXIgc2VjcmV0",
+  );
+});
+
 test("the index is displayed", async () => {
   renderComponent(<ReBACAdmin apiURL="/api" />, {
     url: "/settings/permissions",

--- a/src/components/ReBACAdmin/ReBACAdmin.test.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.test.tsx
@@ -17,11 +17,28 @@ test("the api URL can be configured", () => {
 });
 
 test("the auth token can be configured", () => {
-  const apiURL = "http://example.com/api";
-  renderComponent(<ReBACAdmin apiURL={apiURL} authToken="U3VwZXIgc2VjcmV0" />);
+  renderComponent(
+    <ReBACAdmin apiURL="http://example.com/api" authToken="U3VwZXIgc2VjcmV0" />,
+  );
   expect(axios.defaults.headers.common["X-Authorization"]).toBe(
     "U3VwZXIgc2VjcmV0",
   );
+});
+
+test("the header is not set if there is no auth token", () => {
+  renderComponent(<ReBACAdmin apiURL="http://example.com/api" />);
+  expect(axios.defaults.headers.common["X-Authorization"]).toBeUndefined();
+});
+
+test("the header is removed if the auth token is unset", () => {
+  const { result } = renderComponent(
+    <ReBACAdmin apiURL="http://example.com/api" authToken="U3VwZXIgc2VjcmV0" />,
+  );
+  expect(axios.defaults.headers.common["X-Authorization"]).toBe(
+    "U3VwZXIgc2VjcmV0",
+  );
+  result.rerender(<ReBACAdmin apiURL="http://example.com/api" />);
+  expect(axios.defaults.headers.common["X-Authorization"]).toBeUndefined();
 });
 
 test("the index is displayed", async () => {

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -31,7 +31,11 @@ const ReBACAdmin = ({ apiURL, asidePanelId, authToken }: Props) => {
   axios.defaults.baseURL = apiURL;
 
   useEffect(() => {
-    axios.defaults.headers.common["X-Authorization"] = authToken;
+    if (authToken) {
+      axios.defaults.headers.common["X-Authorization"] = authToken;
+    } else if (axios.defaults.headers.common["X-Authorization"]) {
+      delete axios.defaults.headers.common["X-Authorization"];
+    }
   }, [authToken]);
 
   return (

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -1,19 +1,26 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import axios from "axios";
+import { useEffect } from "react";
+import { Toaster } from "react-hot-toast";
 import { Route, Routes } from "react-router-dom";
 
 import Panel from "components/Panel";
 import Groups from "components/pages/Groups";
 import Roles from "components/pages/Roles";
 import Users from "components/pages/Users";
+import { ReBACAdminContext } from "context/ReBACAdminContext";
 import urls from "urls";
 
 export type Props = {
   // The absolute API URL.
   apiURL: `${"http" | "/"}${string}`;
+  // The element ID to use to render aside panels into. Should not begin with "#".
+  asidePanelId?: string | null;
+  // The base64 encoded user id for the authenticated user.
+  authToken?: string | null;
 };
 
-const ReBACAdmin = ({ apiURL }: Props) => {
+const ReBACAdmin = ({ apiURL, asidePanelId, authToken }: Props) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -23,34 +30,41 @@ const ReBACAdmin = ({ apiURL }: Props) => {
   });
   axios.defaults.baseURL = apiURL;
 
+  useEffect(() => {
+    axios.defaults.headers.common["X-Authorization"] = authToken;
+  }, [authToken]);
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <Routes>
-        <Route
-          path={urls.index}
-          element={<Panel title="Canonical ReBAC Admin" />}
-        />
-        <Route
-          path={urls.accessGovernance.index}
-          element={<Panel title="Access Governance" />}
-        />
-        <Route
-          path={urls.authentication.index}
-          element={<Panel title="Authentication" />}
-        />
-        <Route
-          path={urls.entitlements}
-          element={<Panel title="Entitlements" />}
-        />
-        <Route path={urls.groups.index} element={<Groups />} />
-        <Route
-          path={urls.resources.index}
-          element={<Panel title="Resources" />}
-        />
-        <Route path={urls.roles.index} element={<Roles />} />
-        <Route path={urls.users.index} element={<Users />} />
-      </Routes>
-    </QueryClientProvider>
+    <ReBACAdminContext.Provider value={{ asidePanelId }}>
+      <QueryClientProvider client={queryClient}>
+        <Routes>
+          <Route
+            path={urls.index}
+            element={<Panel title="Canonical ReBAC Admin" />}
+          />
+          <Route
+            path={urls.accessGovernance.index}
+            element={<Panel title="Access Governance" />}
+          />
+          <Route
+            path={urls.authentication.index}
+            element={<Panel title="Authentication" />}
+          />
+          <Route
+            path={urls.entitlements}
+            element={<Panel title="Entitlements" />}
+          />
+          <Route path={urls.groups.index} element={<Groups />} />
+          <Route
+            path={urls.resources.index}
+            element={<Panel title="Resources" />}
+          />
+          <Route path={urls.roles.index} element={<Roles />} />
+          <Route path={urls.users.index} element={<Users />} />
+        </Routes>
+        <Toaster position="bottom-right" />
+      </QueryClientProvider>
+    </ReBACAdminContext.Provider>
   );
 };
 

--- a/src/components/ToastCard/ToastCard.test.tsx
+++ b/src/components/ToastCard/ToastCard.test.tsx
@@ -1,0 +1,146 @@
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import cloneDeep from "clone-deep";
+import { Toaster } from "react-hot-toast";
+import reactHotToast from "react-hot-toast";
+import { vi } from "vitest";
+
+import ToastCard from "./ToastCard";
+import type { Props } from "./types";
+
+describe("Toast Card", () => {
+  const toastInstanceExample: Props["toastInstance"] = {
+    createdAt: 1623162274616,
+    duration: 5000,
+    id: "2",
+    message: "message",
+    pauseDuration: 0,
+    style: {},
+    type: "custom",
+    visible: true,
+  };
+
+  test("should display message", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(screen.getByText("I am a toast message")).toHaveClass(
+      "toast-card__message",
+    );
+  });
+
+  test("should display as correct type", () => {
+    const t = cloneDeep(toastInstanceExample);
+    const { container } = render(
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(container.firstChild).toHaveAttribute("data-type", "positive");
+  });
+
+  test("should display correct success icon", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="positive" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(document.querySelector(".p-icon--success")).toBeInTheDocument();
+  });
+
+  test("should display correct error icon", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(document.querySelector(".p-icon--error")).toBeInTheDocument();
+  });
+
+  test("should display correct warning icon", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="caution" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(document.querySelector(".p-icon--warning")).toBeInTheDocument();
+  });
+
+  test("should display close icon", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(screen.getByRole("button", { name: "Close" })).toHaveClass(
+      "p-icon--close",
+    );
+  });
+
+  test("should not display an undo button if an undo function is not passed", () => {
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="negative" toastInstance={t}>
+        I am a toast message
+      </ToastCard>,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Undo" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("should display a clickable undo button if an undo function is passed", async () => {
+    const undoFn = vi.fn();
+    const t = cloneDeep(toastInstanceExample);
+    render(
+      <ToastCard type="negative" toastInstance={t} undo={undoFn}>
+        I am a toast message
+      </ToastCard>,
+    );
+    const undoButton = screen.getByRole("button", { name: "Undo" });
+    expect(undoButton).toBeInTheDocument();
+    await act(async () => await userEvent.click(undoButton));
+    expect(undoFn).toHaveBeenCalled();
+  });
+
+  test("should remove the card when close is clicked", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      reactHotToast.custom((t) => (
+        <ToastCard type="negative" toastInstance={t}>
+          I am a toast message
+        </ToastCard>
+      ));
+    });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    await act(
+      async () =>
+        await userEvent.click(screen.getByRole("button", { name: "Close" })),
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  test("should close the card using the keyboard", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      reactHotToast.custom((t) => (
+        <ToastCard type="negative" toastInstance={t}>
+          I am a toast message
+        </ToastCard>
+      ));
+    });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    fireEvent.keyUp(screen.getByRole("button", { name: "Close" }), {
+      key: " ",
+      code: "Space",
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ToastCard/ToastCard.tsx
+++ b/src/components/ToastCard/ToastCard.tsx
@@ -1,0 +1,68 @@
+import reactHotToast from "react-hot-toast";
+
+import type { Props } from "./types";
+
+import "./_toast-card.scss";
+
+export default function ToastCard({
+  children,
+  toastInstance,
+  type,
+  undo,
+}: Props) {
+  let iconName;
+  switch (type) {
+    case "positive":
+      iconName = "success";
+      break;
+    case "caution":
+      iconName = "warning";
+      break;
+    case "negative":
+      iconName = "error";
+      break;
+    default:
+      break;
+  }
+
+  const handleClose = (id: string) => {
+    reactHotToast.remove(id);
+  };
+
+  return (
+    <div
+      className="toast-card"
+      data-type={type}
+      role="status"
+      aria-live="polite"
+      data-testid="toast-card"
+    >
+      <div className="toast-card__body">
+        {iconName && <i className={`p-icon--${iconName}`}>Success</i>}
+        <div className="toast-card__message">{children}</div>
+        <i
+          className="p-icon--close"
+          onClick={() => handleClose(toastInstance.id)}
+          onKeyUp={() => handleClose(toastInstance.id)}
+          role="button"
+          tabIndex={0}
+        >
+          Close
+        </i>
+      </div>
+      {undo && (
+        <footer className="toast-card__undo">
+          <button
+            onClick={() => {
+              undo();
+              handleClose(toastInstance.id);
+            }}
+            className="p-button--base"
+          >
+            Undo
+          </button>
+        </footer>
+      )}
+    </div>
+  );
+}

--- a/src/components/ToastCard/_toast-card.scss
+++ b/src/components/ToastCard/_toast-card.scss
@@ -1,0 +1,61 @@
+@import "vanilla-framework/scss/vanilla";
+
+.toast-container {
+  // These cards need to appear above modals and panels.
+  z-index: 10003 !important;
+}
+
+.toast-card {
+  background-color: $color-x-light;
+  border: 1px solid $color-mid-light;
+  border-radius: 5px;
+  box-shadow: $box-shadow;
+  color: $color-dark;
+  max-width: 350px;
+  padding: 1rem 0.75rem;
+  width: 100%;
+
+  &__body {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: 1rem 1fr 1rem;
+  }
+
+  &__message {
+    word-break: break-word;
+  }
+
+  i {
+    display: inline-block;
+    padding-top: 1.5rem;
+  }
+
+  .p-icon--close {
+    cursor: pointer;
+    padding-top: 1.5rem;
+  }
+
+  &[data-type="positive"] {
+    border-left: 3px solid $color-positive;
+  }
+
+  &[data-type="caution"] {
+    border-left: 3px solid $color-caution;
+  }
+
+  &[data-type="negative"] {
+    border-left: 3px solid $color-negative;
+  }
+
+  &__undo {
+    display: flex;
+    width: 100%;
+
+    [class~="p-button"] {
+      color: $color-link;
+      margin-bottom: 0;
+      margin-left: auto;
+      width: auto;
+    }
+  }
+}

--- a/src/components/ToastCard/index.ts
+++ b/src/components/ToastCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ToastCard";
+export * from "./types";

--- a/src/components/ToastCard/types.ts
+++ b/src/components/ToastCard/types.ts
@@ -1,0 +1,8 @@
+import type { PropsWithChildren } from "react";
+import type { Toast } from "react-hot-toast";
+
+export type Props = {
+  toastInstance: Omit<Toast, "ariaProps">;
+  type: "positive" | "caution" | "negative";
+  undo?: () => void;
+} & PropsWithChildren;

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
@@ -1,0 +1,64 @@
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupServer } from "msw/node";
+import { vi } from "vitest";
+
+import {
+  getPostRolesResponseMock,
+  getPostRolesMockHandler,
+} from "api/roles/roles.msw";
+import { getPostRolesErrorMockHandler } from "mocks/roles";
+import { hasNotification, hasToast, renderComponent } from "test/utils";
+
+import { Label as RolePanelLabel } from "../RolePanel";
+
+import AddRolePanel from "./AddRolePanel";
+
+const mockRolesData = getPostRolesResponseMock({
+  message: "Role was created!",
+});
+const mockApiServer = setupServer(getPostRolesMockHandler(mockRolesData));
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should add a role", async () => {
+  renderComponent(<AddRolePanel close={vi.fn()} />);
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: RolePanelLabel.NAME }),
+        "role1{Enter}",
+      ),
+  );
+  await hasToast("Role was created!", "positive");
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should handle errors when adding roles", async () => {
+  mockApiServer.use(
+    getPostRolesErrorMockHandler(500, "That role already exists"),
+  );
+  renderComponent(<AddRolePanel close={vi.fn()} />);
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: RolePanelLabel.NAME }),
+        "role1{Enter}",
+      ),
+  );
+  await hasNotification(
+    "Unable to create role: That role already exists",
+    "negative",
+  );
+});

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
@@ -1,0 +1,45 @@
+import { useQueryClient } from "@tanstack/react-query";
+import reactHotToast from "react-hot-toast";
+
+import { usePostRoles } from "api/roles/roles";
+import ToastCard from "components/ToastCard";
+import { Endpoint } from "types/api";
+
+import RolePanel from "../RolePanel";
+
+import type { Props } from "./types";
+
+const AddRolePanel = ({ close }: Props) => {
+  const queryClient = useQueryClient();
+  const { error, mutate, isPending } = usePostRoles();
+
+  return (
+    <RolePanel
+      close={close}
+      error={
+        error ? `Unable to create role: ${error.response?.data.message}` : null
+      }
+      isSaving={isPending}
+      onSubmit={({ id }) => {
+        mutate(
+          { data: { id } },
+          {
+            onSuccess: ({ data }) => {
+              close();
+              reactHotToast.custom((t) => (
+                <ToastCard toastInstance={t} type="positive">
+                  {data.message}
+                </ToastCard>
+              ));
+              void queryClient.invalidateQueries({
+                queryKey: [Endpoint.ROLES],
+              });
+            },
+          },
+        );
+      }}
+    />
+  );
+};
+
+export default AddRolePanel;

--- a/src/components/pages/Roles/AddRolePanel/index.ts
+++ b/src/components/pages/Roles/AddRolePanel/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./AddRolePanel";
+export * from "./types";

--- a/src/components/pages/Roles/AddRolePanel/types.ts
+++ b/src/components/pages/Roles/AddRolePanel/types.ts
@@ -1,0 +1,5 @@
+import type { Props as RolePanelProps } from "../RolePanel";
+
+export type Props = {
+  close: RolePanelProps["close"];
+};

--- a/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
@@ -1,0 +1,43 @@
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupServer } from "msw/node";
+import { vi } from "vitest";
+
+import {
+  getPostRolesResponseMock,
+  getPostRolesMockHandler,
+} from "api/roles/roles.msw";
+import { renderComponent } from "test/utils";
+
+import RolePanel from "./RolePanel";
+import { Label } from "./types";
+
+const mockRolesData = getPostRolesResponseMock({
+  message: "Role was created!",
+});
+const mockApiServer = setupServer(getPostRolesMockHandler(mockRolesData));
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+test("can submit the form", async () => {
+  const onSubmit = vi.fn();
+  renderComponent(<RolePanel close={vi.fn()} onSubmit={onSubmit} />);
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: Label.NAME }),
+        "role1{Enter}",
+      ),
+  );
+  expect(onSubmit).toHaveBeenCalled();
+});

--- a/src/components/pages/Roles/RolePanel/RolePanel.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.tsx
@@ -1,0 +1,29 @@
+import { FormikField } from "@canonical/react-components";
+
+import PanelForm from "components/PanelForm";
+
+import type { FormFields } from "./types";
+import { Label, type Props } from "./types";
+
+const RolePanel = ({ close, error, roleId, onSubmit, isSaving }: Props) => {
+  const isEditing = !!roleId;
+  return (
+    <PanelForm<FormFields>
+      close={close}
+      entity="role"
+      error={error}
+      initialValues={{ id: "" }}
+      isSaving={isSaving}
+      onSubmit={onSubmit}
+    >
+      <FormikField
+        label={Label.NAME}
+        name="id"
+        takeFocus={!isEditing}
+        type="text"
+      />
+    </PanelForm>
+  );
+};
+
+export default RolePanel;

--- a/src/components/pages/Roles/RolePanel/index.ts
+++ b/src/components/pages/Roles/RolePanel/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./RolePanel";
+export * from "./types";

--- a/src/components/pages/Roles/RolePanel/types.ts
+++ b/src/components/pages/Roles/RolePanel/types.ts
@@ -1,0 +1,15 @@
+export type FormFields = {
+  id: string;
+};
+
+export type Props = {
+  close: () => void;
+  error?: string | null;
+  isSaving?: boolean;
+  onSubmit: (values: FormFields) => void;
+  roleId?: string | null;
+};
+
+export enum Label {
+  NAME = "Role name",
+}

--- a/src/components/pages/Roles/RolePanelButton/RolePanelButton.test.tsx
+++ b/src/components/pages/Roles/RolePanelButton/RolePanelButton.test.tsx
@@ -1,0 +1,37 @@
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ReBACAdminContext } from "context/ReBACAdminContext";
+import { renderComponent } from "test/utils";
+
+import RolePanelButton from "./RolePanelButton";
+
+test("can display add state", async () => {
+  renderComponent(<RolePanelButton />);
+  expect(
+    screen.getByRole("button", { name: "Create role" }),
+  ).toBeInTheDocument();
+});
+
+test("can display edit state", async () => {
+  renderComponent(<RolePanelButton roleId="role1" />);
+  expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+});
+
+test("can display the add panel", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
+      <div id="aside-panel"></div>
+      <RolePanelButton />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create role" }),
+      ),
+  );
+  const heading = screen.getByRole("heading", { name: "Create role" });
+  expect(heading).toBeInTheDocument();
+  expect(heading.closest(".p-panel")).toBeInTheDocument();
+});

--- a/src/components/pages/Roles/RolePanelButton/RolePanelButton.tsx
+++ b/src/components/pages/Roles/RolePanelButton/RolePanelButton.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@canonical/react-components";
+
+import { usePanelPortal } from "hooks/usePanelPortal";
+
+import AddRolePanel from "../AddRolePanel";
+
+import type { Props } from "./types";
+
+const RolePanelButton = ({ roleId }: Props) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal();
+  return (
+    <>
+      <Button appearance={roleId ? "link" : "positive"} onClick={openPortal}>
+        {roleId ? "Edit" : "Create role"}
+      </Button>
+      {isOpen ? (
+        <Portal>{roleId ? null : <AddRolePanel close={closePortal} />}</Portal>
+      ) : null}
+    </>
+  );
+};
+
+export default RolePanelButton;

--- a/src/components/pages/Roles/RolePanelButton/index.ts
+++ b/src/components/pages/Roles/RolePanelButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./RolePanelButton";
+export * from "./types";

--- a/src/components/pages/Roles/RolePanelButton/types.ts
+++ b/src/components/pages/Roles/RolePanelButton/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  roleId?: string | null;
+};

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -6,6 +6,7 @@ import { useGetRoles } from "api/roles/roles";
 import Content from "components/Content";
 import ErrorNotification from "components/ErrorNotification";
 
+import RolePanelButton from "./RolePanelButton";
 import { Label } from "./types";
 
 const COLUMN_DATA: Column[] = [
@@ -51,7 +52,11 @@ const Roles = () => {
     }
   };
 
-  return <Content title="Roles">{generateContent()}</Content>;
+  return (
+    <Content controls={<RolePanelButton />} title="Roles">
+      {generateContent()}
+    </Content>
+  );
 };
 
 export default Roles;

--- a/src/context/ReBACAdminContext.ts
+++ b/src/context/ReBACAdminContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+type Values = {
+  asidePanelId?: string | null;
+};
+
+export const ReBACAdminContext = createContext<Values>({
+  asidePanelId: null,
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { usePanelPortal } from "./usePanelPortal";

--- a/src/hooks/usePanelPortal.test.tsx
+++ b/src/hooks/usePanelPortal.test.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@canonical/react-components";
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ReBACAdminContext } from "context/ReBACAdminContext";
+import { renderComponent } from "test/utils";
+
+import { usePanelPortal } from "./usePanelPortal";
+
+const content = "This is the content";
+const containerId = "portal-container";
+
+const TestComponent = () => {
+  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal();
+  return (
+    <>
+      <Button onClick={isOpen ? closePortal : openPortal}>Toggle</Button>
+      {isOpen ? <Portal>{content}</Portal> : null}
+    </>
+  );
+};
+
+test("displays without a portal", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  expect(screen.queryByText(content)).not.toBeInTheDocument();
+  let container = document.getElementById(containerId);
+  expect(container).not.toHaveClass("l-aside");
+  expect(container?.hasChildNodes()).toBe(false);
+});
+
+test("can display a portal", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Toggle" })),
+  );
+  expect(screen.getByText(content)).toBeInTheDocument();
+  const container = document.getElementById(containerId);
+  expect(container).toHaveClass("l-aside");
+  expect(container?.firstChild).toHaveClass("p-panel");
+});
+
+test("can remove a portal", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Toggle" })),
+  );
+  expect(screen.getByText(content)).toBeInTheDocument();
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Toggle" })),
+  );
+  expect(screen.queryByText(content)).not.toBeInTheDocument();
+  let container = document.getElementById(containerId);
+  expect(container).not.toHaveClass("l-aside");
+  expect(container?.firstChild).not.toHaveClass("p-panel");
+});

--- a/src/hooks/usePanelPortal.ts
+++ b/src/hooks/usePanelPortal.ts
@@ -1,0 +1,34 @@
+import { useContext, useEffect } from "react";
+import usePortal from "react-useportal";
+
+import { ReBACAdminContext } from "context/ReBACAdminContext";
+
+export const usePanelPortal = () => {
+  const { asidePanelId } = useContext(ReBACAdminContext);
+  const portal = usePortal({
+    bindTo: asidePanelId
+      ? document.getElementById(asidePanelId) ?? undefined
+      : undefined,
+  });
+  const { isOpen, portalRef } = portal;
+
+  useEffect(() => {
+    const portalNode = portalRef.current;
+    if (isOpen && asidePanelId) {
+      // The portal container needs to be the aside element as Vanilla
+      // does not allow the aside to be nested.
+      document.getElementById(asidePanelId)?.classList.add("l-aside");
+      // The portal node must have the panel class as Vanilla requires the panel
+      // to be a direct descendent of the aside.
+      portalNode.classList.add("p-panel");
+    }
+    return () => {
+      if (asidePanelId) {
+        document.getElementById(asidePanelId)?.classList.remove("l-aside");
+        portalNode.classList.remove("p-panel");
+      }
+    };
+  }, [isOpen, asidePanelId, portalRef]);
+
+  return portal;
+};

--- a/src/mocks/roles.ts
+++ b/src/mocks/roles.ts
@@ -13,3 +13,21 @@ export const getGetRolesErrorMockHandler = (status: number = 404) => {
     });
   });
 };
+
+export const getPostRolesErrorMockHandler = (
+  status = 500,
+  response?: string,
+) => {
+  return http.post(`*${Endpoint.ROLES}`, async () => {
+    await delay(Number(import.meta.env.VITE_MOCK_API_DELAY));
+    return new HttpResponse(
+      response ? JSON.stringify({ message: response }) : null,
+      {
+        status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};

--- a/src/test/ComponentProviders.tsx
+++ b/src/test/ComponentProviders.tsx
@@ -1,6 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode, PropsWithChildren } from "react";
+import { Toaster } from "react-hot-toast";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 export type ComponentProps = {
@@ -31,6 +32,7 @@ const ComponentProviders = ({
         <Route path="*" element={<span />} />
       </Routes>
     </BrowserRouter>
+    <Toaster />
   </QueryClientProvider>
 );
 

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -68,7 +68,6 @@ export const hasNotification = async (
   severity = NotificationSeverity.NEGATIVE,
 ) => {
   const notification = await screen.findByText(message);
-  expect(notification).toBeInTheDocument();
   expect(
     notification.closest(`.p-notification--${severity}`),
   ).toBeInTheDocument();
@@ -79,7 +78,6 @@ export const hasToast = async (
   severity = NotificationSeverity.POSITIVE,
 ) => {
   const toast = await screen.findByText(message);
-  expect(toast).toBeInTheDocument();
   const card = toast.closest(".toast-card");
   expect(card).toBeInTheDocument();
   expect(card).toHaveAttribute("data-type", severity);

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,5 +1,6 @@
+import { NotificationSeverity } from "@canonical/react-components";
 import { QueryClient } from "@tanstack/react-query";
-import { render, renderHook } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import React from "react";
 import type { ReactNode } from "react";
 
@@ -60,4 +61,26 @@ export const renderWrappedHook = <Result, Props>(
     ),
   });
   return { changeURL, result, queryClient };
+};
+
+export const hasNotification = async (
+  message: string,
+  severity = NotificationSeverity.NEGATIVE,
+) => {
+  const notification = await screen.findByText(message);
+  expect(notification).toBeInTheDocument();
+  expect(
+    notification.closest(`.p-notification--${severity}`),
+  ).toBeInTheDocument();
+};
+
+export const hasToast = async (
+  message: string,
+  severity = NotificationSeverity.POSITIVE,
+) => {
+  const toast = await screen.findByText(message);
+  expect(toast).toBeInTheDocument();
+  const card = toast.closest(".toast-card");
+  expect(card).toBeInTheDocument();
+  expect(card).toHaveAttribute("data-type", severity);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,8 +1950,10 @@ __metadata:
     prettier: "npm:3.2.5"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
+    react-hot-toast: "npm:2.4.1"
     react-router: "npm:6.22.2"
     react-router-dom: "npm:6.22.2"
+    react-useportal: "npm:1.0.19"
     sass: "npm:1.71.1"
     strict-event-emitter: "npm:0.5.1"
     stylelint: "npm:16.2.1"
@@ -7452,6 +7454,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"goober@npm:^2.1.10":
+  version: 2.1.14
+  resolution: "goober@npm:2.1.14"
+  peerDependencies:
+    csstype: ^3.0.10
+  checksum: 10c0/184eda787a9a14cffbaa8284e98dc127095e538b4acab2a84b81babca84253bb883e16208822e02584f27c7a69f3ec47341e5060dfa40a0e07c32ac1f79b2714
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1":
   version: 1.0.1
   resolution: "gopd@npm:1.0.1"
@@ -10276,6 +10287,18 @@ __metadata:
   version: 2.0.4
   resolution: "react-fast-compare@npm:2.0.4"
   checksum: 10c0/f0300c677e95198b5f993cbb8a983dab09586157dc678f9e2b5b29ff941b6677a8776fbbdc425ce102fad86937e36bb45cfcfd797f006270b97ccf287ebfb885
+  languageName: node
+  linkType: hard
+
+"react-hot-toast@npm:2.4.1":
+  version: 2.4.1
+  resolution: "react-hot-toast@npm:2.4.1"
+  dependencies:
+    goober: "npm:^2.1.10"
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 10c0/591ecec3c6adc1cdb70f00165a57baa3d7f75d0d30fa767213c36496bdcc6be2b2e6a3edbf7c04f7d726a1b17dcfb5e7feb2136b04b17c9ccb769894b970f365
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

- Add panel for creating roles.
- Update API spec to match the backend.
- Set auth headers.

## QA

- Set `VITE_DEMO_AUTH_TOKEN` to a base64 version of an administrator's username, see [the docs](https://github.com/canonical/identity-platform-admin-ui/wiki/OpenFGA-setup#api-authorization).
- Go to the roles page.
- Click "Create role"
- Fill in the name and submit.
- The form should close and the table should update with the new role.

## Details

- https://warthogs.atlassian.net/browse/WD-10180

## Screenshots

<img width="1433" alt="Screenshot 2024-04-09 at 4 03 16 PM" src="https://github.com/canonical/rebac-admin/assets/361637/b726bb58-5c39-41c8-9d0d-944f0cec9004">

