### PR TITLE
WD-10181 - feature: add entitlements when creating a role

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -706,6 +706,32 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           $ref: '#/components/responses/default'
+    patch:
+      tags:
+        - roles/{id}
+      summary: Update entitlements of a role
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EntitlementsPatchRequest"
+      responses:
+        "201":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Response"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/default"
   /roles/{id}/entitlements/{entitlementId}:
     parameters:
       - name: id
@@ -952,6 +978,23 @@ components:
         id:
           type: string
       examples: [{ id: "global" }, { id: "administrator" }, { id: "viewer" }]
+    EntitlementsPatchRequest:
+      type: object
+      required:
+        - permissions
+      properties:
+        permissions:
+          type: array
+          items:
+            type: object
+            required:
+              - relation
+              - object
+            properties:
+              relation:
+                type: string
+              object:
+                type: string
     Entity:
       type: string
       examples: ["Controller", "Cloud"]

--- a/src/api/api.schemas.ts
+++ b/src/api/api.schemas.ts
@@ -18,31 +18,9 @@
 
  * OpenAPI spec version: 0.0.8
  */
-export type GetResourcesParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
-};
-
 export type GetRolesId200 = Response & Roles;
 
-export type GetGroupsIdUsersParams = {
-  /**
-   * The number of records to return per response
-   */
-  size?: PaginationSizeParameter;
-  /**
-   * The record offset to return results from
-   */
-  page?: PaginationPageParameter;
-};
-
-export type GetGroupsParams = {
+export type GetRolesParams = {
   /**
    * The number of records to return per response
    */
@@ -56,6 +34,19 @@ export type GetGroupsParams = {
    */
   filter?: FilterParamParameter;
 };
+
+export type GetGroupsIdUsersParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
+};
+
+export type GetUsersIdRoles200 = Response & Roles;
 
 export type GetUsersIdRolesParams = {
   /**
@@ -104,6 +95,17 @@ export type PaginationPageParameter = number;
  */
 export type PaginationSizeParameter = number;
 
+export type GetResourcesParams = {
+  /**
+   * The number of records to return per response
+   */
+  size?: PaginationSizeParameter;
+  /**
+   * The record offset to return results from
+   */
+  page?: PaginationPageParameter;
+};
+
 export type GetEntitlementsParams = {
   /**
    * The number of records to return per response
@@ -130,7 +132,7 @@ export type GetRolesIdEntitlementsParams = {
   page?: PaginationPageParameter;
 };
 
-export type GetRolesParams = {
+export type GetGroupsParams = {
   /**
    * The number of records to return per response
    */
@@ -194,9 +196,9 @@ export type GetAuthenticationProvidersParams = {
 };
 
 /**
- * Unexpected error
+ * Not found
  */
-export type DefaultResponse = Response;
+export type NotFoundResponse = Response;
 
 /**
  * Unauthorized
@@ -233,6 +235,8 @@ export type GetResources200 = Response & Resources;
 
 export type GetEntitlements200 = Response & EntityEntitlements;
 
+export type GetRolesIdEntitlements200 = Response & Entitlements;
+
 export type GetRoles200 = Response & Roles;
 
 export type GetGroupsIdUsers200 = Response & Users;
@@ -243,12 +247,10 @@ export type GetGroups200 = Response & Groups;
 
 export type GetUsersIdEntitlements200 = Response & Entitlements;
 
-export type GetUsersIdRoles200 = Response & Roles;
-
 /**
- * Not found
+ * Unexpected error
  */
-export type NotFoundResponse = Response;
+export type DefaultResponse = Response;
 
 export interface Resource {
   entity: Entity;
@@ -276,9 +278,16 @@ export interface Entitlements {
   data: Entitlement[];
 }
 
-export type GetRolesIdEntitlements200 = Response & Entitlements;
-
 export type Entity = string;
+
+export type EntitlementsPatchRequestPermissionsItem = {
+  object: string;
+  relation: string;
+};
+
+export interface EntitlementsPatchRequest {
+  permissions: EntitlementsPatchRequestPermissionsItem[];
+}
 
 export interface RoleObject {
   id: string;

--- a/src/api/roles-id/roles-id.msw.ts
+++ b/src/api/roles-id/roles-id.msw.ts
@@ -27,6 +27,7 @@ import type {
   GetRolesId200,
   GetRolesIdEntitlements200,
   NotFoundResponse,
+  Response,
   UnauthorizedResponse,
 } from "../api.schemas";
 
@@ -393,6 +394,114 @@ export const getGetRolesIdEntitlementsResponseMock404 = (
 });
 
 export const getGetRolesIdEntitlementsResponseMockDefault = (
+  overrideResponse: any = {},
+): DefaultResponse => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMock = (
+  overrideResponse: any = {},
+): Response => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMock201 = (
+  overrideResponse: any = {},
+): Response => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMock400 = (
+  overrideResponse: any = {},
+): BadRequestResponse => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMock401 = (
+  overrideResponse: any = {},
+): UnauthorizedResponse => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMock404 = (
+  overrideResponse: any = {},
+): NotFoundResponse => ({
+  _links: {
+    next: { href: faker.word.sample(), ...overrideResponse },
+    ...overrideResponse,
+  },
+  _meta: {
+    page: faker.number.int({ min: undefined, max: undefined }),
+    size: faker.number.int({ min: undefined, max: undefined }),
+    total: faker.number.int({ min: undefined, max: undefined }),
+    ...overrideResponse,
+  },
+  message: faker.word.sample(),
+  status: faker.number.int({ min: undefined, max: undefined }),
+  ...overrideResponse,
+});
+
+export const getPatchRolesIdEntitlementsResponseMockDefault = (
   overrideResponse: any = {},
 ): DefaultResponse => ({
   _links: {
@@ -926,6 +1035,132 @@ export const getGetRolesIdEntitlementsMockHandlerDefault = (
   });
 };
 
+export const getPatchRolesIdEntitlementsMockHandler = (
+  overrideResponse?: Response,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMock(),
+      ),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
+export const getPatchRolesIdEntitlementsMockHandler201 = (
+  overrideResponse?: Response,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMock201(),
+      ),
+      {
+        status: 201,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
+export const getPatchRolesIdEntitlementsMockHandler400 = (
+  overrideResponse?: BadRequestResponse,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMock400(),
+      ),
+      {
+        status: 400,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
+export const getPatchRolesIdEntitlementsMockHandler401 = (
+  overrideResponse?: UnauthorizedResponse,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMock401(),
+      ),
+      {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
+export const getPatchRolesIdEntitlementsMockHandler404 = (
+  overrideResponse?: NotFoundResponse,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMock404(),
+      ),
+      {
+        status: 404,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
+export const getPatchRolesIdEntitlementsMockHandlerDefault = (
+  overrideResponse?: DefaultResponse,
+) => {
+  return http.patch("*/roles/:id/entitlements", async () => {
+    await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse
+          ? overrideResponse
+          : getPatchRolesIdEntitlementsResponseMockDefault(),
+      ),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+};
+
 export const getDeleteRolesIdEntitlementsEntitlementIdMockHandler = () => {
   return http.delete("*/roles/:id/entitlements/:entitlementId", async () => {
     await delay((() => (process.env.NODE_ENV === "development" ? 1e3 : 10))());
@@ -1038,5 +1273,6 @@ export const getRolesIdMock = () => [
   getPatchRolesIdMockHandler(),
   getDeleteRolesIdMockHandler(),
   getGetRolesIdEntitlementsMockHandler(),
+  getPatchRolesIdEntitlementsMockHandler(),
   getDeleteRolesIdEntitlementsEntitlementIdMockHandler(),
 ];

--- a/src/api/roles-id/roles-id.ts
+++ b/src/api/roles-id/roles-id.ts
@@ -34,10 +34,12 @@ import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import type {
   BadRequestResponse,
   DefaultResponse,
+  EntitlementsPatchRequest,
   GetRolesId200,
   GetRolesIdEntitlements200,
   GetRolesIdEntitlementsParams,
   NotFoundResponse,
+  Response,
   Role,
   UnauthorizedResponse,
 } from "../api.schemas";
@@ -410,6 +412,94 @@ export const useGetRolesIdEntitlements = <
   return query;
 };
 
+/**
+ * @summary Update entitlements of a role
+ */
+export const patchRolesIdEntitlements = (
+  id: string,
+  entitlementsPatchRequest: EntitlementsPatchRequest,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<Response>> => {
+  return axios.patch(
+    `/roles/${id}/entitlements`,
+    entitlementsPatchRequest,
+    options,
+  );
+};
+
+export const getPatchRolesIdEntitlementsMutationOptions = <
+  TError = AxiosError<
+    | BadRequestResponse
+    | UnauthorizedResponse
+    | NotFoundResponse
+    | DefaultResponse
+  >,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof patchRolesIdEntitlements>>,
+    TError,
+    { id: string; data: EntitlementsPatchRequest },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof patchRolesIdEntitlements>>,
+  TError,
+  { id: string; data: EntitlementsPatchRequest },
+  TContext
+> => {
+  const { mutation: mutationOptions, axios: axiosOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof patchRolesIdEntitlements>>,
+    { id: string; data: EntitlementsPatchRequest }
+  > = (props) => {
+    const { id, data } = props ?? {};
+
+    return patchRolesIdEntitlements(id, data, axiosOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PatchRolesIdEntitlementsMutationResult = NonNullable<
+  Awaited<ReturnType<typeof patchRolesIdEntitlements>>
+>;
+export type PatchRolesIdEntitlementsMutationBody = EntitlementsPatchRequest;
+export type PatchRolesIdEntitlementsMutationError = AxiosError<
+  BadRequestResponse | UnauthorizedResponse | NotFoundResponse | DefaultResponse
+>;
+
+/**
+ * @summary Update entitlements of a role
+ */
+export const usePatchRolesIdEntitlements = <
+  TError = AxiosError<
+    | BadRequestResponse
+    | UnauthorizedResponse
+    | NotFoundResponse
+    | DefaultResponse
+  >,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof patchRolesIdEntitlements>>,
+    TError,
+    { id: string; data: EntitlementsPatchRequest },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationResult<
+  Awaited<ReturnType<typeof patchRolesIdEntitlements>>,
+  TError,
+  { id: string; data: EntitlementsPatchRequest },
+  TContext
+> => {
+  const mutationOptions = getPatchRolesIdEntitlementsMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
 /**
  * @summary Remove an entitlement from a role
  */

--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.test.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.test.tsx
@@ -1,0 +1,151 @@
+import { screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { hasNotification, renderComponent } from "test/utils";
+
+import EntitlementsPanelForm from "./EntitlementsPanelForm";
+import { Label } from "./types";
+
+test("can add entitlements", async () => {
+  const setAddEntitlements = vi.fn();
+  renderComponent(
+    <EntitlementsPanelForm
+      addEntitlements={[
+        {
+          entitlement: "can_view",
+          entity: "admins",
+          resource: "group",
+        },
+      ]}
+      setAddEntitlements={setAddEntitlements}
+    />,
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: Label.ENTITY }),
+        "client",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: Label.RESOURCE }),
+        "editors",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: Label.ENTITLEMENT }),
+        "can_read",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: Label.SUBMIT })),
+  );
+  expect(setAddEntitlements).toHaveBeenCalledWith([
+    {
+      entitlement: "can_view",
+      entity: "admins",
+      resource: "group",
+    },
+    {
+      entitlement: "can_read",
+      entity: "client",
+      resource: "editors",
+    },
+  ]);
+});
+
+test("can display entitlements", async () => {
+  const entitlements = [
+    {
+      entitlement: "can_view",
+      entity: "admins",
+      resource: "group",
+    },
+    {
+      entitlement: "can_read",
+      entity: "editors",
+      resource: "client",
+    },
+  ];
+  renderComponent(
+    <EntitlementsPanelForm
+      addEntitlements={entitlements}
+      setAddEntitlements={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("row", {
+      name: new RegExp(
+        [
+          entitlements[0].entity,
+          entitlements[0].resource,
+          entitlements[0].entitlement,
+        ].join(" "),
+      ),
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("row", {
+      name: new RegExp(
+        [
+          entitlements[1].entity,
+          entitlements[1].resource,
+          entitlements[1].entitlement,
+        ].join(" "),
+      ),
+    }),
+  ).toBeInTheDocument();
+});
+
+test("can remove entitlements", async () => {
+  const entitlements = [
+    {
+      entitlement: "can_view",
+      entity: "admins",
+      resource: "group",
+    },
+    {
+      entitlement: "can_read",
+      entity: "editors",
+      resource: "client",
+    },
+  ];
+  const setAddEntitlements = vi.fn();
+  renderComponent(
+    <EntitlementsPanelForm
+      addEntitlements={entitlements}
+      setAddEntitlements={setAddEntitlements}
+    />,
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", { name: Label.REMOVE })[0],
+      ),
+  );
+  expect(setAddEntitlements).toHaveBeenCalledWith([
+    {
+      entitlement: "can_read",
+      entity: "editors",
+      resource: "client",
+    },
+  ]);
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("can display errors", async () => {
+  renderComponent(
+    <EntitlementsPanelForm
+      error="Uh oh!"
+      addEntitlements={[]}
+      setAddEntitlements={vi.fn()}
+    />,
+  );
+  await hasNotification("Uh oh!");
+});

--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
@@ -1,0 +1,171 @@
+import {
+  Col,
+  Notification,
+  NotificationSeverity,
+  Row,
+  FormikField,
+  ModularTable,
+  Button,
+  Icon,
+} from "@canonical/react-components";
+import { Form, Formik } from "formik";
+import { useMemo } from "react";
+import type { Column } from "react-table";
+import * as Yup from "yup";
+
+import FormikSubmitButton from "components/FormikSubmitButton";
+
+import type { Entitlement } from "./types";
+import { Label, type Props } from "./types";
+
+import "./_entitlements-panel-form.scss";
+
+const schema = Yup.object().shape({
+  entity: Yup.string().required("Required"),
+  resource: Yup.string().required("Required"),
+  entitlement: Yup.string().required("Required"),
+});
+
+const COLUMN_DATA: Column[] = [
+  {
+    Header: "Entity",
+    accessor: "entity",
+  },
+  {
+    Header: "Resource",
+    accessor: "resource",
+  },
+  {
+    Header: "Entitlement",
+    accessor: "entitlement",
+  },
+  {
+    Header: "Actions",
+    accessor: "actions",
+  },
+];
+
+const EntitlementsPanelForm = ({
+  error,
+  addEntitlements,
+  setAddEntitlements,
+}: Props) => {
+  const tableData = useMemo(
+    () =>
+      addEntitlements.map((entitlement) => ({
+        ...entitlement,
+        actions: (
+          <Button
+            appearance="base"
+            hasIcon
+            onClick={() => {
+              setAddEntitlements(
+                addEntitlements.filter((addEntitlement) =>
+                  Object.keys(addEntitlement).some((key) => {
+                    const entitlementKey = key as keyof Entitlement;
+                    return (
+                      addEntitlement[entitlementKey] !==
+                      entitlement[entitlementKey]
+                    );
+                  }),
+                ),
+              );
+            }}
+          >
+            <Icon name="delete" aria-label={Label.REMOVE} />
+          </Button>
+        ),
+      })),
+    [addEntitlements, setAddEntitlements],
+  );
+  return (
+    <>
+      {error ? (
+        <Row>
+          <Col size={12}>
+            <Notification severity={NotificationSeverity.NEGATIVE}>
+              {error}
+            </Notification>
+          </Col>
+        </Row>
+      ) : null}
+
+      <Row>
+        <Col size={12}>
+          <Formik<Entitlement>
+            initialValues={{ resource: "", entitlement: "", entity: "" }}
+            onSubmit={(values, helpers) => {
+              setAddEntitlements([...addEntitlements, values]);
+              helpers.resetForm();
+              document
+                .querySelector<HTMLInputElement>("input[name='resource']")
+                ?.focus();
+            }}
+            validationSchema={schema}
+          >
+            <Form aria-label={Label.FORM}>
+              <fieldset>
+                <h5>Add entitlement tuple</h5>
+                <p className="p-text--small u-text--muted">
+                  In fine-grained authorisation entitlements need to be given in
+                  relation to a specific resource. Select the appropriate
+                  resource and entitlement below and add it to the list of
+                  entitlements for this role.{" "}
+                </p>
+                <div className="entitlements-panel-form__fields">
+                  <FormikField label={Label.ENTITY} name="entity" type="text" />
+                  <FormikField
+                    label={Label.RESOURCE}
+                    name="resource"
+                    type="text"
+                  />
+                  <FormikField
+                    label={Label.ENTITLEMENT}
+                    name="entitlement"
+                    type="text"
+                  />
+                  <div className="entitlements-panel-form__submit">
+                    <FormikSubmitButton>{Label.SUBMIT}</FormikSubmitButton>
+                  </div>
+                </div>
+              </fieldset>
+            </Form>
+          </Formik>
+        </Col>
+      </Row>
+      <Row>
+        <Col size={12}>
+          <ModularTable
+            getCellProps={({ column }) => {
+              switch (column.id) {
+                case "actions":
+                  return {
+                    className: "u-align--right",
+                  };
+
+                default:
+                  return {};
+              }
+            }}
+            getHeaderProps={({ id }) => {
+              switch (id) {
+                case "actions":
+                  return {
+                    className: "u-align--right",
+                  };
+
+                default:
+                  return {};
+              }
+            }}
+            columns={COLUMN_DATA}
+            data={tableData}
+            emptyMsg="No entitlements have been added."
+          />
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default EntitlementsPanelForm;

--- a/src/components/EntitlementsPanelForm/_entitlements-panel-form.scss
+++ b/src/components/EntitlementsPanelForm/_entitlements-panel-form.scss
@@ -1,0 +1,12 @@
+@import "vanilla-framework/scss/vanilla";
+
+.entitlements-panel-form {
+  &__fields {
+    display: flex;
+    gap: $sph--large;
+  }
+
+  &__submit {
+    padding-top: $spv--large * 2 + $spv--small;
+  }
+}

--- a/src/components/EntitlementsPanelForm/index.ts
+++ b/src/components/EntitlementsPanelForm/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./EntitlementsPanelForm";
+export * from "./types";

--- a/src/components/EntitlementsPanelForm/types.ts
+++ b/src/components/EntitlementsPanelForm/types.ts
@@ -1,0 +1,20 @@
+export type Entitlement = {
+  entitlement: string;
+  entity: string;
+  resource: string;
+};
+
+export type Props = {
+  addEntitlements: Entitlement[];
+  error?: string | null;
+  setAddEntitlements: (addEntitlements: Entitlement[]) => void;
+};
+
+export enum Label {
+  ENTITLEMENT = "Entitlement",
+  ENTITY = "Resource type",
+  FORM = "Add entitlement",
+  RESOURCE = "Resource",
+  REMOVE = "Remove entitlement",
+  SUBMIT = "Add",
+}

--- a/src/components/FormikSubmitButton/FormikSubmitButton.test.tsx
+++ b/src/components/FormikSubmitButton/FormikSubmitButton.test.tsx
@@ -1,0 +1,104 @@
+import { FormikField } from "@canonical/react-components";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Form, Formik } from "formik";
+import { vi } from "vitest";
+import * as Yup from "yup";
+
+import { renderComponent } from "test/utils";
+
+import FormikSubmitButton from "./FormikSubmitButton";
+
+test("submits the form", async () => {
+  const onSubmit = vi.fn();
+  renderComponent(
+    <Formik initialValues={{ resource: "" }} onSubmit={onSubmit}>
+      <Form>
+        <FormikField name="resource" type="text" />
+        <FormikSubmitButton>Go!</FormikSubmitButton>
+      </Form>
+    </Formik>,
+  );
+  await act(
+    async () => await userEvent.type(screen.getByRole("textbox"), "hello"),
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Go!" })),
+  );
+  expect(onSubmit).toHaveBeenCalled();
+});
+
+test("can be manually disabled", async () => {
+  renderComponent(
+    <Formik initialValues={{}} onSubmit={vi.fn()}>
+      <Form>
+        <FormikSubmitButton disabled>Go!</FormikSubmitButton>
+      </Form>
+    </Formik>,
+  );
+  expect(screen.getByRole("button", { name: "Go!" })).toBeDisabled();
+});
+
+test("is disabled if the form is not dirty", async () => {
+  const schema = Yup.object().shape({
+    resource: Yup.number(),
+  });
+  renderComponent(
+    <Formik
+      initialValues={{ resource: "" }}
+      onSubmit={vi.fn()}
+      validationSchema={schema}
+    >
+      <Form>
+        <FormikField name="resource" type="text" />
+        <FormikSubmitButton>Go!</FormikSubmitButton>
+      </Form>
+    </Formik>,
+  );
+  expect(screen.getByRole("button", { name: "Go!" })).toBeDisabled();
+});
+
+test("is disabled if there are errors", async () => {
+  const schema = Yup.object().shape({
+    resource: Yup.number(),
+  });
+  renderComponent(
+    <Formik
+      initialValues={{ resource: "" }}
+      onSubmit={vi.fn()}
+      validationSchema={schema}
+    >
+      <Form>
+        <FormikField name="resource" type="text" />
+        <FormikSubmitButton>Go!</FormikSubmitButton>
+      </Form>
+    </Formik>,
+  );
+  await act(
+    async () => await userEvent.type(screen.getByRole("textbox"), "hello"),
+  );
+  expect(screen.getByRole("button", { name: "Go!" })).toBeDisabled();
+});
+
+test("can be enabled", async () => {
+  const schema = Yup.object().shape({
+    resource: Yup.string(),
+  });
+  renderComponent(
+    <Formik
+      initialValues={{ resource: "" }}
+      onSubmit={vi.fn()}
+      validationSchema={schema}
+    >
+      <Form>
+        <FormikField name="resource" type="text" />
+        <FormikSubmitButton>Go!</FormikSubmitButton>
+      </Form>
+    </Formik>,
+  );
+  await act(
+    async () => await userEvent.type(screen.getByRole("textbox"), "hello"),
+  );
+  expect(screen.getByRole("button", { name: "Go!" })).not.toBeDisabled();
+});

--- a/src/components/FormikSubmitButton/FormikSubmitButton.tsx
+++ b/src/components/FormikSubmitButton/FormikSubmitButton.tsx
@@ -1,0 +1,22 @@
+import { ActionButton } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import { type Props } from "./types";
+
+const FormikSubmitButton = ({
+  appearance = "positive",
+  disabled,
+  ...props
+}: Props) => {
+  const { dirty, isValid } = useFormikContext();
+  return (
+    <ActionButton
+      {...props}
+      appearance={appearance}
+      disabled={disabled || !isValid || !dirty}
+      type="submit"
+    />
+  );
+};
+
+export default FormikSubmitButton;

--- a/src/components/FormikSubmitButton/index.ts
+++ b/src/components/FormikSubmitButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FormikSubmitButton";
+export * from "./types";

--- a/src/components/FormikSubmitButton/types.ts
+++ b/src/components/FormikSubmitButton/types.ts
@@ -1,0 +1,3 @@
+import type { ActionButtonProps } from "@canonical/react-components";
+
+export type Props = ActionButtonProps;

--- a/src/components/PanelForm/PanelForm.tsx
+++ b/src/components/PanelForm/PanelForm.tsx
@@ -1,15 +1,20 @@
 import {
-  ActionButton,
   Button,
   Col,
   Notification,
   NotificationSeverity,
   Row,
 } from "@canonical/react-components";
+import classNames from "classnames";
 import type { FormikValues } from "formik";
 import { Form, Formik } from "formik";
+import { useState } from "react";
 
-import { Label, type Props } from "./types";
+import FormikSubmitButton from "components/FormikSubmitButton";
+
+import PanelFormLink from "./PanelFormLink";
+import PanelFormNavigation from "./PanelFormNavigation";
+import { Label, TestId, type Props } from "./types";
 
 const PanelForm = <F extends FormikValues>({
   children,
@@ -18,52 +23,80 @@ const PanelForm = <F extends FormikValues>({
   error,
   isEditing,
   isSaving,
+  subForms,
   ...props
 }: Props<F>) => {
+  const [view, setView] = useState<string | null>();
   // This component does not use the Panel component as Vanilla requires a strict
   // element hierarchy that can't be achieved using the normal components in
   // conjunction with portals.
   return (
     <>
       <div className="p-panel__header">
-        <h4 className="p-panel__title">
-          {isEditing ? `Edit ${entity}` : `Create ${entity}`}
-        </h4>
+        <div className="p-panel__title">
+          <PanelFormNavigation
+            panelEntity={entity}
+            setView={setView}
+            view={view}
+          />
+        </div>
       </div>
       <div className="p-panel__content">
-        {error ? (
-          <Row>
-            <Col size={12}>
-              <Notification severity={NotificationSeverity.NEGATIVE}>
-                {error}
-              </Notification>
-            </Col>
-          </Row>
-        ) : null}
-        <Formik<F> {...props}>
-          <Form>
+        {view
+          ? subForms.find((subForm) => subForm.entity === view)?.view
+          : null}
+        <div
+          className={classNames({
+            // Hide the form when displaying a different view. This will retain
+            // the form values when returning to the initial form.
+            "u-hide": !!view,
+          })}
+          data-testid={TestId.DEFAULT_VIEW}
+        >
+          {error ? (
             <Row>
-              <Col size={12}>{children}</Col>
-            </Row>
-            <Row className="u-align--right">
               <Col size={12}>
-                <hr />
-              </Col>
-              <Col size={12}>
-                <Button appearance="base" onClick={close} type="button">
-                  {Label.CANCEL}
-                </Button>
-                <ActionButton
-                  appearance="positive"
-                  loading={isSaving}
-                  type="submit"
-                >
-                  {isEditing ? `Update ${entity}` : `Create ${entity}`}
-                </ActionButton>
+                <Notification severity={NotificationSeverity.NEGATIVE}>
+                  {error}
+                </Notification>
               </Col>
             </Row>
-          </Form>
-        </Formik>
+          ) : null}
+          <Formik<F> {...props}>
+            <Form>
+              <Row>
+                <Col size={12}>{children}</Col>
+              </Row>
+              <Row>
+                <Col size={12}>
+                  {subForms.map(({ count, entity, icon }) => (
+                    <PanelFormLink
+                      entity={entity}
+                      count={count}
+                      icon={icon}
+                      isEditing={isEditing}
+                      key={entity}
+                      onClick={() => setView(entity)}
+                    />
+                  ))}
+                </Col>
+              </Row>
+              <Row className="u-align--right">
+                <Col size={12}>
+                  <hr />
+                </Col>
+                <Col size={12}>
+                  <Button appearance="base" onClick={close} type="button">
+                    {Label.CANCEL}
+                  </Button>
+                  <FormikSubmitButton loading={isSaving}>
+                    {isEditing ? `Update ${entity}` : `Create ${entity}`}
+                  </FormikSubmitButton>
+                </Col>
+              </Row>
+            </Form>
+          </Formik>
+        </div>
       </div>
     </>
   );

--- a/src/components/PanelForm/PanelFormLink/PanelFormLink.test.tsx
+++ b/src/components/PanelForm/PanelFormLink/PanelFormLink.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { renderComponent } from "test/utils";
+
+import PanelFormLink from "./PanelFormLink";
+
+test("handles clicks", async () => {
+  const onClick = vi.fn();
+  renderComponent(
+    <PanelFormLink count={1} entity="role" icon="user" onClick={onClick} />,
+  );
+  await userEvent.click(screen.getByRole("button"));
+  expect(onClick).toHaveBeenCalled();
+});
+
+test("displays count for 0 entities", async () => {
+  renderComponent(
+    <PanelFormLink count={0} entity="role" icon="user" onClick={vi.fn()} />,
+  );
+  expect(screen.getByText("No roles")).toBeInTheDocument();
+});
+
+test("displays count for 1 entity", async () => {
+  renderComponent(
+    <PanelFormLink count={1} entity="role" icon="user" onClick={vi.fn()} />,
+  );
+  expect(screen.getByText("1 role")).toBeInTheDocument();
+});
+
+test("displays count for more than 1 entity", async () => {
+  renderComponent(
+    <PanelFormLink count={2} entity="role" icon="user" onClick={vi.fn()} />,
+  );
+  expect(screen.getByText("2 roles")).toBeInTheDocument();
+});

--- a/src/components/PanelForm/PanelFormLink/PanelFormLink.tsx
+++ b/src/components/PanelForm/PanelFormLink/PanelFormLink.tsx
@@ -1,0 +1,34 @@
+import { Button, Icon } from "@canonical/react-components";
+
+import { type Props } from "./types";
+import { generateTitle } from "./utils";
+
+import "./_panel-form-link.scss";
+
+const PanelFormLink = ({ count, entity, icon, isEditing, onClick }: Props) => {
+  return (
+    <Button
+      appearance="base"
+      className="panel-form-link"
+      onClick={() => onClick(entity)}
+      type="button"
+    >
+      <span className="panel-form-link__column">
+        <Icon name={icon} className="panel-form-link__icon" />
+        <span className="panel-form-link__title">
+          {generateTitle(entity, isEditing)}
+        </span>
+      </span>
+      <span className="panel-form-link__column u-align--right">
+        <span className="panel-form-link__count u-text--muted">
+          {count === 0
+            ? `No ${entity}s`
+            : `${count} ${entity}${count > 1 ? "s" : ""}`}
+        </span>
+        <Icon name="chevron-right" />
+      </span>
+    </Button>
+  );
+};
+
+export default PanelFormLink;

--- a/src/components/PanelForm/PanelFormLink/_panel-form-link.scss
+++ b/src/components/PanelForm/PanelFormLink/_panel-form-link.scss
@@ -1,0 +1,28 @@
+@import "vanilla-framework/scss/vanilla";
+
+button.panel-form-link {
+  display: flex;
+  width: 100%;
+
+  .panel-form-link__column {
+    align-self: center;
+    flex: 1 1 auto;
+    text-align: left;
+  }
+
+  .panel-form-link__count {
+    margin-right: $sph--large;
+  }
+
+  .panel-form-link__title {
+    margin-top: -$spv--large;
+    vertical-align: middle;
+  }
+
+  [class*="p-icon"].panel-form-link__icon {
+    height: $sp-x-large;
+    margin-right: $sph--x-large;
+    vertical-align: middle;
+    width: $sp-x-large;
+  }
+}

--- a/src/components/PanelForm/PanelFormLink/index.ts
+++ b/src/components/PanelForm/PanelFormLink/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PanelFormLink";
+export * from "./types";

--- a/src/components/PanelForm/PanelFormLink/types.ts
+++ b/src/components/PanelForm/PanelFormLink/types.ts
@@ -1,0 +1,9 @@
+import type { SubForm } from "components/PanelForm";
+
+export type Props = {
+  count: SubForm["count"];
+  entity: SubForm["entity"];
+  icon: SubForm["icon"];
+  isEditing?: boolean;
+  onClick: (entity: string) => void;
+};

--- a/src/components/PanelForm/PanelFormLink/utils.test.ts
+++ b/src/components/PanelForm/PanelFormLink/utils.test.ts
@@ -1,0 +1,9 @@
+import { generateTitle } from "./utils";
+
+test("can generate an add title", async () => {
+  expect(generateTitle("role")).toBe("Add roles");
+});
+
+test("can generate an edit title", async () => {
+  expect(generateTitle("role", true)).toBe("Edit roles");
+});

--- a/src/components/PanelForm/PanelFormLink/utils.ts
+++ b/src/components/PanelForm/PanelFormLink/utils.ts
@@ -1,0 +1,2 @@
+export const generateTitle = (entity: string, isEditing?: boolean) =>
+  `${isEditing ? "Edit" : "Add"} ${entity}s`;

--- a/src/components/PanelForm/PanelFormNavigation/PanelFormNavigation.test.tsx
+++ b/src/components/PanelForm/PanelFormNavigation/PanelFormNavigation.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { renderComponent } from "test/utils";
+
+import PanelFormNavigation from "./PanelFormNavigation";
+
+test("displays the parent navigation", async () => {
+  renderComponent(<PanelFormNavigation panelEntity="role" setView={vi.fn()} />);
+  expect(document.querySelectorAll(".p-breadcrumbs__item")).toHaveLength(1);
+  const title = screen.getByText("Create role");
+  expect(title).toBeInTheDocument();
+  expect(title.closest(".p-heading--4")).toBeInTheDocument();
+});
+
+test("displays the child navigation", async () => {
+  renderComponent(
+    <PanelFormNavigation panelEntity="role" setView={vi.fn()} view="group" />,
+  );
+  expect(document.querySelectorAll(".p-breadcrumbs__item")).toHaveLength(2);
+  expect(
+    screen.getByRole("button", { name: "Create role" }),
+  ).toBeInTheDocument();
+  const title = screen.getByText("Add groups");
+  expect(title).toBeInTheDocument();
+  expect(title.closest(".p-heading--4")).toBeInTheDocument();
+});
+
+test("handles navigating to the parent", async () => {
+  const setView = vi.fn();
+  renderComponent(
+    <PanelFormNavigation panelEntity="role" setView={setView} view="group" />,
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Create role" }));
+  expect(setView).toHaveBeenCalled();
+});
+
+test("displays when editing", async () => {
+  renderComponent(
+    <PanelFormNavigation
+      isEditing
+      panelEntity="role"
+      setView={vi.fn()}
+      view="group"
+    />,
+  );
+  expect(screen.getByText("Edit role")).toBeInTheDocument();
+  expect(screen.getByText("Edit groups")).toBeInTheDocument();
+});

--- a/src/components/PanelForm/PanelFormNavigation/PanelFormNavigation.tsx
+++ b/src/components/PanelForm/PanelFormNavigation/PanelFormNavigation.tsx
@@ -1,0 +1,43 @@
+import { Button, Icon } from "@canonical/react-components";
+
+import { generateTitle } from "../PanelFormLink/utils";
+
+import { PanelFormNavigationTitleId } from "./consts";
+import { type Props } from "./types";
+
+import "./_panel-form-navigation.scss";
+
+const PanelFormNavigation = ({
+  isEditing,
+  panelEntity,
+  setView,
+  view,
+}: Props) => {
+  const panelTitle = isEditing
+    ? `Edit ${panelEntity}`
+    : `Create ${panelEntity}`;
+  const viewTitle = view ? generateTitle(view, isEditing) : null;
+  return (
+    <nav className="p-breadcrumbs panel-form-navigation">
+      <ol className="p-breadcrumbs__items">
+        {view ? (
+          <li className="p-breadcrumbs__item">
+            <Button appearance="link" onClick={() => setView(null)}>
+              <Icon name="chevron-left" /> {panelTitle}
+            </Button>
+          </li>
+        ) : null}
+        <li className="p-breadcrumbs__item">
+          <span
+            className="p-heading--4 panel-form-navigation__current-title"
+            id={PanelFormNavigationTitleId}
+          >
+            {viewTitle ?? panelTitle}
+          </span>
+        </li>
+      </ol>
+    </nav>
+  );
+};
+
+export default PanelFormNavigation;

--- a/src/components/PanelForm/PanelFormNavigation/_panel-form-navigation.scss
+++ b/src/components/PanelForm/PanelFormNavigation/_panel-form-navigation.scss
@@ -1,0 +1,13 @@
+.panel-form-navigation {
+  &__current-title {
+    vertical-align: sub;
+  }
+
+  .p-breadcrumbs__item {
+    font-variant-caps: unset;
+
+    button {
+      text-transform: uppercase;
+    }
+  }
+}

--- a/src/components/PanelForm/PanelFormNavigation/consts.ts
+++ b/src/components/PanelForm/PanelFormNavigation/consts.ts
@@ -1,0 +1,1 @@
+export const PanelFormNavigationTitleId = "panel-navigation-current";

--- a/src/components/PanelForm/PanelFormNavigation/index.ts
+++ b/src/components/PanelForm/PanelFormNavigation/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PanelFormNavigation";
+export * from "./types";

--- a/src/components/PanelForm/PanelFormNavigation/types.ts
+++ b/src/components/PanelForm/PanelFormNavigation/types.ts
@@ -1,0 +1,7 @@
+export type Props = {
+  isEditing?: boolean;
+  panelEntity: string;
+  panelLabelId?: string;
+  setView: (view?: string | null) => void;
+  view?: string | null;
+};

--- a/src/components/PanelForm/types.ts
+++ b/src/components/PanelForm/types.ts
@@ -1,5 +1,12 @@
 import type { FormikConfig, FormikValues } from "formik";
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
+
+export type SubForm = {
+  count: number;
+  entity: string;
+  icon: string;
+  view: ReactNode;
+};
 
 export type Props<F extends FormikValues> = {
   close: () => void;
@@ -7,9 +14,14 @@ export type Props<F extends FormikValues> = {
   error?: string | null;
   isEditing?: boolean;
   isSaving?: boolean;
+  subForms: SubForm[];
 } & PropsWithChildren &
   Omit<FormikConfig<F>, "children">;
 
 export enum Label {
   CANCEL = "Cancel",
+}
+
+export enum TestId {
+  DEFAULT_VIEW = "default-view",
 }

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -11,6 +11,8 @@ import Users from "components/pages/Users";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 import urls from "urls";
 
+import "scss/index.scss";
+
 export type Props = {
   // The absolute API URL.
   apiURL: `${"http" | "/"}${string}`;

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
@@ -10,7 +10,11 @@ import {
   getPostRolesMockHandler400,
   getPostRolesResponseMock400,
 } from "api/roles/roles.msw";
-import { getPatchRolesIdEntitlementsMockHandler } from "api/roles-id/roles-id.msw";
+import {
+  getPatchRolesIdEntitlementsMockHandler,
+  getPatchRolesIdEntitlementsMockHandler400,
+  getPatchRolesIdEntitlementsResponseMock400,
+} from "api/roles-id/roles-id.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
 import { hasNotification, hasToast, renderComponent } from "test/utils";
 
@@ -154,9 +158,10 @@ test("should handle errors when adding roles", async () => {
 test("should handle errors when adding entitlements", async () => {
   mockApiServer.use(
     getPostRolesMockHandler(mockRolesData),
-    getPatchRolesIdEntitlementsErrorMockHandler(
-      500,
-      "No resource with that name found",
+    getPatchRolesIdEntitlementsMockHandler400(
+      getPatchRolesIdEntitlementsResponseMock400({
+        message: "No resource with that name found",
+      }),
     ),
   );
   renderComponent(<AddRolePanel close={vi.fn()} />);

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
@@ -1,4 +1,5 @@
-import { screen, act } from "@testing-library/react";
+import { NotificationSeverity } from "@canonical/react-components";
+import { screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
 import { vi } from "vitest";
@@ -9,16 +10,19 @@ import {
   getPostRolesMockHandler400,
   getPostRolesResponseMock400,
 } from "api/roles/roles.msw";
+import { getPatchRolesIdEntitlementsMockHandler } from "api/roles-id/roles-id.msw";
+import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
 import { hasNotification, hasToast, renderComponent } from "test/utils";
 
 import { Label as RolePanelLabel } from "../RolePanel";
 
 import AddRolePanel from "./AddRolePanel";
 
-const mockRolesData = getPostRolesResponseMock({
-  message: "Role was created!",
-});
-const mockApiServer = setupServer(getPostRolesMockHandler(mockRolesData));
+const mockRolesData = getPostRolesResponseMock();
+const mockApiServer = setupServer(
+  getPostRolesMockHandler(mockRolesData),
+  getPatchRolesIdEntitlementsMockHandler(),
+);
 
 beforeAll(() => {
   mockApiServer.listen();
@@ -42,7 +46,87 @@ test("should add a role", async () => {
         "role1{Enter}",
       ),
   );
-  await hasToast("Role was created!", "positive");
+  await hasToast('Role "role1" was created.', "positive");
+});
+
+test("should add a role and entitlements", async () => {
+  let responseBody: string | null = null;
+  let done = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/roles/role1/entitlements")
+    ) {
+      responseBody = await requestClone.text();
+      done = true;
+    }
+  });
+  renderComponent(<AddRolePanel close={vi.fn()} />);
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: RolePanelLabel.NAME }),
+        "role1",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: /Add entitlements/ }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.ENTITY,
+        }),
+        "client",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.RESOURCE,
+        }),
+        "editors",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.ENTITLEMENT,
+        }),
+        "can_read",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: EntitlementsPanelFormLabel.SUBMIT }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Create role" })[0],
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create role" }),
+      ),
+  );
+  await hasToast('Role "role1" was created.', "positive");
+  await waitFor(() => expect(done).toBeTruthy());
+  expect(responseBody).toBe(
+    '{"permissions":[{"object":"client:editors","relation":"can_read"}]}',
+  );
 });
 
 // eslint-disable-next-line vitest/expect-expect
@@ -63,5 +147,79 @@ test("should handle errors when adding roles", async () => {
   await hasNotification(
     "Unable to create role: That role already exists",
     "negative",
+  );
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should handle errors when adding entitlements", async () => {
+  mockApiServer.use(
+    getPostRolesMockHandler(mockRolesData),
+    getPatchRolesIdEntitlementsErrorMockHandler(
+      500,
+      "No resource with that name found",
+    ),
+  );
+  renderComponent(<AddRolePanel close={vi.fn()} />);
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", { name: RolePanelLabel.NAME }),
+        "role1",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: /Add entitlements/ }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.ENTITY,
+        }),
+        "client",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.RESOURCE,
+        }),
+        "editors",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: EntitlementsPanelFormLabel.ENTITLEMENT,
+        }),
+        "can_read",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: EntitlementsPanelFormLabel.SUBMIT }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Create role" })[0],
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Create role" }),
+      ),
+  );
+  await hasToast(
+    'Entitlements couldn\'t be added: "No resource with that name found".',
+    NotificationSeverity.NEGATIVE,
   );
 });

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
@@ -1,7 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import reactHotToast from "react-hot-toast";
 
 import { usePostRoles } from "api/roles/roles";
+import { usePatchRolesIdEntitlements } from "api/roles-id/roles-id";
 import ToastCard from "components/ToastCard";
 import { Endpoint } from "types/api";
 
@@ -11,32 +13,66 @@ import type { Props } from "./types";
 
 const AddRolePanel = ({ close }: Props) => {
   const queryClient = useQueryClient();
-  const { error, mutate, isPending } = usePostRoles();
+  const {
+    error: postRolesError,
+    mutateAsync: postRoles,
+    isPending: isPostRolesPending,
+  } = usePostRoles();
+  const {
+    mutateAsync: patchRolesIdEntitlements,
+    isPending: isPatchRolesIdEntitlementsPending,
+  } = usePatchRolesIdEntitlements();
 
   return (
     <RolePanel
       close={close}
       error={
-        error ? `Unable to create role: ${error.response?.data.message}` : null
+        postRolesError
+          ? `Unable to create role: ${postRolesError.response?.data.message}`
+          : null
       }
-      isSaving={isPending}
-      onSubmit={({ id }) => {
-        mutate(
-          { data: { id } },
-          {
-            onSuccess: ({ data }) => {
-              close();
-              reactHotToast.custom((t) => (
-                <ToastCard toastInstance={t} type="positive">
-                  {data.message}
-                </ToastCard>
-              ));
-              void queryClient.invalidateQueries({
-                queryKey: [Endpoint.ROLES],
-              });
-            },
-          },
-        );
+      isSaving={isPostRolesPending || isPatchRolesIdEntitlementsPending}
+      onSubmit={async ({ id }, addEntitlements) => {
+        try {
+          await postRoles({ data: { id } });
+        } catch (error) {
+          // These errors are handled by the errors returned by `usePostRoles`.
+          return;
+        }
+        if (addEntitlements.length) {
+          try {
+            await patchRolesIdEntitlements({
+              id,
+              data: {
+                permissions: addEntitlements.map(
+                  ({ resource, entitlement, entity }) => ({
+                    object: `${entity}:${resource}`,
+                    relation: entitlement,
+                  }),
+                ),
+              },
+            });
+          } catch (error) {
+            reactHotToast.custom((t) => (
+              <ToastCard toastInstance={t} type="negative">
+                {`Entitlements couldn't be added: "${
+                  error instanceof AxiosError
+                    ? error.response?.data.message
+                    : "unknown error"
+                }".`}
+              </ToastCard>
+            ));
+          }
+        }
+        void queryClient.invalidateQueries({
+          queryKey: [Endpoint.ROLES],
+        });
+        close();
+        reactHotToast.custom((t) => (
+          <ToastCard toastInstance={t} type="positive">
+            {`Role "${id}" was created.`}
+          </ToastCard>
+        ));
       }}
     />
   );

--- a/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
@@ -1,33 +1,12 @@
 import { screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { setupServer } from "msw/node";
 import { vi } from "vitest";
 
-import {
-  getPostRolesResponseMock,
-  getPostRolesMockHandler,
-} from "api/roles/roles.msw";
+import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
 import { renderComponent } from "test/utils";
 
 import RolePanel from "./RolePanel";
 import { Label } from "./types";
-
-const mockRolesData = getPostRolesResponseMock({
-  message: "Role was created!",
-});
-const mockApiServer = setupServer(getPostRolesMockHandler(mockRolesData));
-
-beforeAll(() => {
-  mockApiServer.listen();
-});
-
-afterEach(() => {
-  mockApiServer.resetHandlers();
-});
-
-afterAll(() => {
-  mockApiServer.close();
-});
 
 test("can submit the form", async () => {
   const onSubmit = vi.fn();
@@ -40,4 +19,26 @@ test("can submit the form", async () => {
       ),
   );
   expect(onSubmit).toHaveBeenCalled();
+});
+
+test("the input is disabled when editing", async () => {
+  renderComponent(
+    <RolePanel close={vi.fn()} roleId="admin" onSubmit={vi.fn()} />,
+  );
+  expect(screen.getByRole("textbox", { name: Label.NAME })).toBeDisabled();
+});
+
+test("the entitlement form can be displayed", async () => {
+  renderComponent(
+    <RolePanel close={vi.fn()} roleId="admin" onSubmit={vi.fn()} />,
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: /Add entitlements/ }),
+      ),
+  );
+  expect(
+    screen.getByRole("form", { name: EntitlementsPanelFormLabel.FORM }),
+  ).toBeInTheDocument();
 });

--- a/src/components/pages/Roles/RolePanel/RolePanel.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.tsx
@@ -1,11 +1,20 @@
 import { FormikField } from "@canonical/react-components";
+import { useState } from "react";
+import * as Yup from "yup";
 
+import type { Entitlement } from "components/EntitlementsPanelForm";
+import EntitlementsPanelForm from "components/EntitlementsPanelForm";
 import PanelForm from "components/PanelForm";
 
 import type { FormFields } from "./types";
 import { Label, type Props } from "./types";
 
+const schema = Yup.object().shape({
+  id: Yup.string().required("Required"),
+});
+
 const RolePanel = ({ close, error, roleId, onSubmit, isSaving }: Props) => {
+  const [addEntitlements, setAddEntitlements] = useState<Entitlement[]>([]);
   const isEditing = !!roleId;
   return (
     <PanelForm<FormFields>
@@ -14,9 +23,24 @@ const RolePanel = ({ close, error, roleId, onSubmit, isSaving }: Props) => {
       error={error}
       initialValues={{ id: "" }}
       isSaving={isSaving}
-      onSubmit={onSubmit}
+      onSubmit={async (values) => await onSubmit(values, addEntitlements)}
+      subForms={[
+        {
+          count: addEntitlements.length,
+          entity: "entitlement",
+          icon: "lock-locked",
+          view: (
+            <EntitlementsPanelForm
+              addEntitlements={addEntitlements}
+              setAddEntitlements={setAddEntitlements}
+            />
+          ),
+        },
+      ]}
+      validationSchema={schema}
     >
       <FormikField
+        disabled={isEditing}
         label={Label.NAME}
         name="id"
         takeFocus={!isEditing}

--- a/src/components/pages/Roles/RolePanel/types.ts
+++ b/src/components/pages/Roles/RolePanel/types.ts
@@ -1,3 +1,5 @@
+import type { Entitlement } from "components/EntitlementsPanelForm";
+
 export type FormFields = {
   id: string;
 };
@@ -6,7 +8,10 @@ export type Props = {
   close: () => void;
   error?: string | null;
   isSaving?: boolean;
-  onSubmit: (values: FormFields) => void;
+  onSubmit: (
+    values: FormFields,
+    addEntitlements: Entitlement[],
+  ) => Promise<void>;
   roleId?: string | null;
 };
 

--- a/src/components/pages/Roles/RolePanelButton/RolePanelButton.test.tsx
+++ b/src/components/pages/Roles/RolePanelButton/RolePanelButton.test.tsx
@@ -21,7 +21,7 @@ test("can display edit state", async () => {
 test("can display the add panel", async () => {
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
-      <div id="aside-panel"></div>
+      <aside id="aside-panel"></aside>
       <RolePanelButton />
     </ReBACAdminContext.Provider>,
   );
@@ -31,7 +31,8 @@ test("can display the add panel", async () => {
         screen.getByRole("button", { name: "Create role" }),
       ),
   );
-  const heading = screen.getByRole("heading", { name: "Create role" });
-  expect(heading).toBeInTheDocument();
-  expect(heading.closest(".p-panel")).toBeInTheDocument();
+  const panel = await screen.findByRole("complementary", {
+    name: "Create role",
+  });
+  expect(panel).toBeInTheDocument();
 });

--- a/src/components/pages/Roles/RolePanelButton/RolePanelButton.tsx
+++ b/src/components/pages/Roles/RolePanelButton/RolePanelButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@canonical/react-components";
 
+import { PanelFormNavigationTitleId } from "components/PanelForm/PanelFormNavigation/consts";
 import { usePanelPortal } from "hooks/usePanelPortal";
 
 import AddRolePanel from "../AddRolePanel";
@@ -7,7 +8,10 @@ import AddRolePanel from "../AddRolePanel";
 import type { Props } from "./types";
 
 const RolePanelButton = ({ roleId }: Props) => {
-  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal();
+  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal(
+    "is-medium",
+    PanelFormNavigationTitleId,
+  );
   return (
     <>
       <Button appearance={roleId ? "link" : "positive"} onClick={openPortal}>

--- a/src/hooks/usePanelPortal.test.tsx
+++ b/src/hooks/usePanelPortal.test.tsx
@@ -10,8 +10,8 @@ import { usePanelPortal } from "./usePanelPortal";
 const content = "This is the content";
 const containerId = "portal-container";
 
-const TestComponent = () => {
-  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal();
+const TestComponent = ({ classes }: { classes?: string }) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePanelPortal(classes);
   return (
     <>
       <Button onClick={isOpen ? closePortal : openPortal}>Toggle</Button>
@@ -70,4 +70,18 @@ test("can remove a portal", async () => {
   let container = document.getElementById(containerId);
   expect(container).not.toHaveClass("l-aside");
   expect(container?.firstChild).not.toHaveClass("p-panel");
+});
+
+test("can add and remove additional classes", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent classes="extra-class" />
+    </ReBACAdminContext.Provider>,
+  );
+  const toggle = screen.getByRole("button", { name: "Toggle" });
+  await act(async () => await userEvent.click(toggle));
+  expect(document.getElementById(containerId)).toHaveClass("extra-class");
+  await act(async () => await userEvent.click(toggle));
+  expect(document.getElementById(containerId)).not.toHaveClass("extra-class");
 });

--- a/src/hooks/usePanelPortal.ts
+++ b/src/hooks/usePanelPortal.ts
@@ -3,7 +3,7 @@ import usePortal from "react-useportal";
 
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 
-export const usePanelPortal = () => {
+export const usePanelPortal = (className?: string, labelledBy?: string) => {
   const { asidePanelId } = useContext(ReBACAdminContext);
   const portal = usePortal({
     bindTo: asidePanelId
@@ -17,18 +17,32 @@ export const usePanelPortal = () => {
     if (isOpen && asidePanelId) {
       // The portal container needs to be the aside element as Vanilla
       // does not allow the aside to be nested.
-      document.getElementById(asidePanelId)?.classList.add("l-aside");
+      const asideNode = document.getElementById(asidePanelId);
+      asideNode?.classList.add("l-aside");
+      if (className) {
+        asideNode?.classList.add(className);
+      }
+      if (labelledBy) {
+        asideNode?.setAttribute("aria-labelledby", labelledBy);
+      }
       // The portal node must have the panel class as Vanilla requires the panel
       // to be a direct descendent of the aside.
       portalNode.classList.add("p-panel");
     }
     return () => {
       if (asidePanelId) {
-        document.getElementById(asidePanelId)?.classList.remove("l-aside");
+        const asideNode = document.getElementById(asidePanelId);
+        asideNode?.classList.remove("l-aside");
+        if (className) {
+          asideNode?.classList.remove(className);
+        }
+        if (labelledBy) {
+          asideNode?.removeAttribute("aria-labelledby");
+        }
         portalNode.classList.remove("p-panel");
       }
     };
-  }, [isOpen, asidePanelId, portalRef]);
+  }, [isOpen, asidePanelId, portalRef, className, labelledBy]);
 
   return portal;
 };

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,3 +1,22 @@
-.todo {
-  color: #fff;
+@import "vanilla-framework/scss/vanilla";
+@include vanilla;
+@include vf-p-icon-settings;
+@include vf-p-icon-lock-locked;
+
+.p-icon--chevron-left {
+  @extend %icon;
+  @include vf-icon-chevron($color-mid-dark);
+
+  transform: rotate(90deg);
+}
+
+.p-icon--chevron-right {
+  @extend %icon;
+  @include vf-icon-chevron($color-mid-dark);
+
+  transform: rotate(270deg);
+}
+
+.l-application .l-aside.is-medium {
+  width: 45rem;
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,13 @@
+import { configure } from "@testing-library/react";
 import type { Window as HappyDOMWindow } from "happy-dom";
 import "@testing-library/jest-dom/vitest";
 
 declare global {
   interface Window extends HappyDOMWindow {}
 }
+
+configure({
+  // Needs to be long enough to handle multiple requests that have the 900ms
+  // delay set in the Orval mocks.
+  asyncUtilTimeout: 5000,
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -75,7 +75,7 @@ export const hasNotification = async (
 
 export const hasToast = async (
   message: string,
-  severity = NotificationSeverity.POSITIVE,
+  severity: string = NotificationSeverity.POSITIVE,
 ) => {
   const toast = await screen.findByText(message);
   const card = toast.closest(".toast-card");


### PR DESCRIPTION
## Done

- Add entitlements panel.
- Submit the request to add entitlements once the role has been created.
- Update openapi.yaml to add the entitlements patch request.
- 

## QA

- Connect to the real API.
- Open the 'Create role' panel.
- Fill out the role name.
- Click "Add entitlements".
- Fill out the form. Some values need to be value so you can use something like: 
  - Resource type: "client"
  - Resource: "aws"
  - Entitlement: "can_view"
  - Click the "Create role" link at the top to go back to the first screen.
  - Click the "Create role" button and the role should get added.
  - If you want to see that the entitlements were created you can check the output of `fga tuple read --simple-output --api-url http://127.0.0.1:8080 --store-id $STORE_ID`


## Details

- https://warthogs.atlassian.net/browse/WD-10181

## Screenshots

<img width="807" alt="Screenshot 2024-04-11 at 3 52 36 PM" src="https://github.com/canonical/rebac-admin/assets/361637/0205fb37-252a-4793-a206-d4536f4d94dd">

