### PR TITLE
WD-10346 - fix: prevent form panels from closing when clicking outside/pressing escape

### DIFF
--- a/src/hooks/usePanelPortal.test.tsx
+++ b/src/hooks/usePanelPortal.test.tsx
@@ -85,3 +85,43 @@ test("can add and remove additional classes", async () => {
   await act(async () => await userEvent.click(toggle));
   expect(document.getElementById(containerId)).not.toHaveClass("extra-class");
 });
+
+test("should not close portal when clicking esc", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Toggle" })),
+  );
+  expect(screen.getByText(content)).toBeInTheDocument();
+  const container = document.getElementById(containerId);
+  expect(container).toHaveClass("l-aside");
+  expect(container?.firstChild).toHaveClass("p-panel");
+  await act(async () => await userEvent.keyboard("{Escape}"));
+  expect(container).toHaveClass("l-aside");
+  expect(container?.firstChild).toHaveClass("p-panel");
+});
+
+test("should not close portal when clicking outside the panel", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Toggle" })),
+  );
+  expect(screen.getByText(content)).toBeInTheDocument();
+  const container = document.getElementById(containerId);
+  expect(container).toHaveClass("l-aside");
+  expect(container?.firstChild).toHaveClass("p-panel");
+  await act(async () => await userEvent.click(document.body));
+  expect(container).toHaveClass("l-aside");
+  expect(container?.firstChild).toHaveClass("p-panel");
+});

--- a/src/hooks/usePanelPortal.ts
+++ b/src/hooks/usePanelPortal.ts
@@ -15,8 +15,8 @@ export const usePanelPortal = (
     bindTo: asidePanelId
       ? document.getElementById(asidePanelId) ?? undefined
       : undefined,
-    closeOnOutsideClick: false,
     closeOnEsc: false,
+    closeOnOutsideClick: false,
   });
   const { isOpen, portalRef } = portal;
 

--- a/src/hooks/usePanelPortal.ts
+++ b/src/hooks/usePanelPortal.ts
@@ -15,6 +15,8 @@ export const usePanelPortal = (
     bindTo: asidePanelId
       ? document.getElementById(asidePanelId) ?? undefined
       : undefined,
+    closeOnOutsideClick: false,
+    closeOnEsc: false,
   });
   const { isOpen, portalRef } = portal;
 


### PR DESCRIPTION
## Done

- Prevent form panels from closing when clicking outside/pressing escape.

## Details

- https://warthogs.atlassian.net/browse/WD-10346