### PR TITLE
WD-10189 - feat: edit a group's users

### DIFF
--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -11,11 +11,20 @@ import {
   getGetGroupsIdEntitlementsResponseMock,
   getDeleteGroupsIdEntitlementsEntitlementIdMockHandler,
   getGetGroupsIdEntitlementsMockHandler400,
+  getGetGroupsIdIdentitiesMockHandler,
+  getGetGroupsIdIdentitiesResponseMock,
+  getDeleteGroupsIdIdentitiesIdentityIdMockHandler,
+  getPatchGroupsIdIdentitiesMockHandler,
+  getPatchGroupsIdIdentitiesMockHandler400,
+  getDeleteGroupsIdIdentitiesIdentityIdMockHandler400,
 } from "api/groups-id/groups-id.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
 import { hasToast, renderComponent } from "test/utils";
 
+import { Label as IdentitiesPanelFormLabel } from "../IdentitiesPanelForm/types";
+
 import EditGroupPanel from "./EditGroupPanel";
+import { Label } from "./types";
 
 const mockApiServer = setupServer(
   getPatchGroupsIdEntitlementsMockHandler(),
@@ -23,6 +32,13 @@ const mockApiServer = setupServer(
   getGetGroupsIdEntitlementsMockHandler(
     getGetGroupsIdEntitlementsResponseMock({
       data: ["can_edit::moderators:collection", "can_remove::staff:team"],
+    }),
+  ),
+  getPatchGroupsIdIdentitiesMockHandler(),
+  getDeleteGroupsIdIdentitiesIdentityIdMockHandler(),
+  getGetGroupsIdIdentitiesMockHandler(
+    getGetGroupsIdIdentitiesResponseMock({
+      data: ["user1", "user2"],
     }),
   ),
 );
@@ -204,8 +220,116 @@ test("should handle errors when updating entitlements", async () => {
         screen.getByRole("button", { name: "Update group" }),
       ),
   );
-  await hasToast(
-    "Some entitlements couldn't be updated",
-    NotificationSeverity.NEGATIVE,
+  await hasToast(Label.ENTITLEMENTS_ERROR, NotificationSeverity.NEGATIVE);
+});
+
+test("should add and remove users", async () => {
+  let patchResponseBody: string | null = null;
+  let patchDone = false;
+  let deleteDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/groups/admin/identities")
+    ) {
+      patchResponseBody = await requestClone.text();
+      patchDone = true;
+    }
+    if (
+      requestClone.method === "DELETE" &&
+      requestClone.url.endsWith("/groups/admin/identities/user1")
+    ) {
+      deleteDone = true;
+    }
+  });
+  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  // Wait until the users have loaded.
+  await screen.findByText("2 users");
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: /Edit users/ })),
   );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", {
+          name: IdentitiesPanelFormLabel.REMOVE,
+        })[0],
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: IdentitiesPanelFormLabel.USER,
+        }),
+        "joe",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Edit group" })[0],
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Update group" }),
+      ),
+  );
+  await waitFor(() => expect(patchDone && deleteDone).toBeTruthy());
+  expect(patchResponseBody).toBe('{"identities":["joe"]}');
+  await hasToast('Group "admin" was updated.', "positive");
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should handle errors when updating users", async () => {
+  mockApiServer.use(
+    getPatchGroupsIdIdentitiesMockHandler400(),
+    getDeleteGroupsIdIdentitiesIdentityIdMockHandler400(),
+  );
+  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  // Wait until the users have loaded.
+  await screen.findByText("2 users");
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: /Edit users/ })),
+  );
+  await act(
+    async () =>
+      await userEvent.type(
+        screen.getByRole("textbox", {
+          name: IdentitiesPanelFormLabel.USER,
+        }),
+        "joe",
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Edit group" })[0],
+      ),
+  );
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Update group" }),
+      ),
+  );
+  await hasToast(Label.IDENTITIES_ERROR, NotificationSeverity.NEGATIVE);
 });

--- a/src/components/pages/Groups/EditGroupPanel/types.ts
+++ b/src/components/pages/Groups/EditGroupPanel/types.ts
@@ -4,3 +4,9 @@ export type Props = {
   close: GroupPanelProps["close"];
   groupId: string;
 };
+
+export enum Label {
+  ENTITLEMENTS_ERROR = "Some entitlements couldn't be updated.",
+  IDENTITIES_ERROR = "Some users couldn't be updated.",
+  ROLES_ERROR = "Some roles couldn't be updated.",
+}

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
@@ -40,7 +40,14 @@ const GroupPanel = ({
   return (
     <SubFormPanel<FormFields>
       {...props}
-      submitEnabled={!!addEntitlements.length || !!removeEntitlements.length}
+      submitEnabled={
+        !!addEntitlements.length ||
+        !!removeEntitlements.length ||
+        !!addIdentities.length ||
+        !!removeIdentities.length ||
+        !!addRoles.length ||
+        !!removeRoles.length
+      }
       entity="group"
       initialValues={{ id: groupId ?? "" }}
       isEditing={isEditing}


### PR DESCRIPTION
## Done

- Add support for editing the users in a group.

## QA

- Go to the groups page and open the edit panel.
- Click on 'Edit users' and add some users.
- Go back to the first screen and submit the form.
- Open the edit panel again and you should see the new users.
- Now try removing some users from the group. When you save you'll get an error due to this issue: https://github.com/canonical/rebac-admin/pull/94#issuecomment-2081788918

## Details

https://warthogs.atlassian.net/browse/WD-10189
