### PR TITLE
WD-10190 - feat: edit roles for a group

### DIFF
--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -24,10 +24,9 @@ import {
   getPostGroupsIdRolesMockHandler400,
 } from "api/groups-id/groups-id.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
+import { Label as IdentitiesPanelFormLabel } from "components/pages/Groups/IdentitiesPanelForm/types";
+import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm/types";
 import { hasToast, renderComponent } from "test/utils";
-
-import { Label as IdentitiesPanelFormLabel } from "../IdentitiesPanelForm/types";
-import { Label as RolesPanelFormLabel } from "../RolesPanelForm/types";
 
 import EditGroupPanel from "./EditGroupPanel";
 import { Label } from "./types";

--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -7,7 +7,11 @@ import {
   getGetGroupsMockHandler404,
   getGetGroupsResponseMock,
 } from "api/groups/groups.msw";
-import { getGetGroupsIdEntitlementsMockHandler } from "api/groups-id/groups-id.msw";
+import {
+  getGetGroupsIdEntitlementsMockHandler,
+  getGetGroupsIdIdentitiesMockHandler,
+  getGetGroupsIdRolesMockHandler,
+} from "api/groups-id/groups-id.msw";
 import { TestId as NoEntityCardTestId } from "components/NoEntityCard";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 import { renderComponent } from "test/utils";
@@ -21,6 +25,8 @@ const mockGroupsData = getGetGroupsResponseMock({
 const mockApiServer = setupServer(
   getGetGroupsMockHandler(mockGroupsData),
   getGetGroupsIdEntitlementsMockHandler(),
+  getGetGroupsIdIdentitiesMockHandler(),
+  getGetGroupsIdRolesMockHandler(),
 );
 
 beforeAll(() => {


### PR DESCRIPTION
## Done

- Add the ability to edit roles in a group.

## QA

- Go to the groups page and edit a group.
- Click "Edit roles".
- Add and remove some roles (note: the roles you remove need to exist, so if they don't then go to the roles page and add them).
- Submit the form to save the group.
- Reopen the edit panel and you should see the changed roles.

## Details

https://warthogs.atlassian.net/browse/WD-10190
