### PR TITLE
WD-10954 - feat: support changing panel widths

### DIFF
--- a/src/components/SubFormPanel/PanelFormNavigation/PanelFormNavigation.test.tsx
+++ b/src/components/SubFormPanel/PanelFormNavigation/PanelFormNavigation.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
+import { PanelWidth } from "hooks/usePanel";
 import { renderComponent } from "test/utils";
 
 import PanelFormNavigation from "./PanelFormNavigation";
@@ -30,10 +31,15 @@ test("displays the child navigation", async () => {
 test("handles navigating to the parent", async () => {
   const setView = vi.fn();
   renderComponent(
-    <PanelFormNavigation panelEntity="role" setView={setView} view="group" />,
+    <PanelFormNavigation
+      defaultPanelWidth={PanelWidth.WIDE}
+      panelEntity="role"
+      setView={setView}
+      view="group"
+    />,
   );
   await userEvent.click(screen.getByRole("button", { name: "Create role" }));
-  expect(setView).toHaveBeenCalled();
+  expect(setView).toHaveBeenCalledWith(null, PanelWidth.WIDE);
 });
 
 test("displays when editing", async () => {

--- a/src/components/SubFormPanel/PanelFormNavigation/PanelFormNavigation.tsx
+++ b/src/components/SubFormPanel/PanelFormNavigation/PanelFormNavigation.tsx
@@ -9,6 +9,7 @@ import { type Props } from "./types";
 import "./_panel-form-navigation.scss";
 
 const PanelFormNavigation = ({
+  defaultPanelWidth,
   isEditing,
   panelEntity,
   setView,
@@ -23,7 +24,11 @@ const PanelFormNavigation = ({
       <ol className="p-breadcrumbs__items">
         {view ? (
           <li className="p-breadcrumbs__item">
-            <Button appearance="link" onClick={() => setView(null)}>
+            <Button
+              className="u-no-margin--bottom"
+              appearance="link"
+              onClick={() => setView(null, defaultPanelWidth)}
+            >
               <Icon name="chevron-left" /> {panelTitle}
             </Button>
           </li>

--- a/src/components/SubFormPanel/PanelFormNavigation/types.ts
+++ b/src/components/SubFormPanel/PanelFormNavigation/types.ts
@@ -1,7 +1,10 @@
+import type { PanelWidth } from "hooks/usePanel";
+
 export type Props = {
+  defaultPanelWidth?: PanelWidth;
   isEditing?: boolean;
   panelEntity: string;
   panelLabelId?: string;
-  setView: (view?: string | null) => void;
+  setView: (view: string | null, panelWidth?: PanelWidth | null) => void;
   view?: string | null;
 };

--- a/src/components/SubFormPanel/SubFormPanel.test.tsx
+++ b/src/components/SubFormPanel/SubFormPanel.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
 import { ReBACAdminContext } from "context/ReBACAdminContext";
+import { PanelWidth } from "hooks/usePanel";
 import { renderComponent } from "test/utils";
 
 import SubFormPanel from "./SubFormPanel";
@@ -15,6 +16,7 @@ test("can display contents", async () => {
       entity="role"
       initialValues={{ name: "" }}
       onSubmit={vi.fn()}
+      setPanelWidth={vi.fn()}
       subForms={[]}
     >
       Form content
@@ -30,6 +32,7 @@ test("can display add state", async () => {
       entity="role"
       initialValues={{ name: "" }}
       onSubmit={vi.fn()}
+      setPanelWidth={vi.fn()}
       subForms={[]}
     >
       Form content
@@ -49,6 +52,7 @@ test("can display edit state", async () => {
       initialValues={{ name: "" }}
       isEditing
       onSubmit={vi.fn()}
+      setPanelWidth={vi.fn()}
       subForms={[]}
     >
       Form content
@@ -60,7 +64,28 @@ test("can display edit state", async () => {
   ).toBeInTheDocument();
 });
 
+test("the initial width is set", async () => {
+  const setPanelWidth = vi.fn();
+  renderComponent(
+    <SubFormPanel<{ name: string }>
+      close={vi.fn()}
+      entity="role"
+      initialValues={{ name: "" }}
+      isEditing
+      onSubmit={vi.fn()}
+      panelWidth={PanelWidth.WIDE}
+      setPanelWidth={setPanelWidth}
+      subForms={[]}
+    >
+      Form content
+    </SubFormPanel>,
+  );
+  expect(screen.getByTestId(TestId.DEFAULT_VIEW)).toBeInTheDocument();
+  expect(setPanelWidth).toHaveBeenCalledWith(PanelWidth.WIDE);
+});
+
 test("can display a subform", async () => {
+  const setPanelWidth = vi.fn();
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
       <div id="aside-panel"></div>
@@ -69,11 +94,13 @@ test("can display a subform", async () => {
         entity="role"
         initialValues={{ name: "" }}
         onSubmit={vi.fn()}
+        setPanelWidth={setPanelWidth}
         subForms={[
           {
             count: 4,
             entity: "entitlement",
             icon: "user",
+            panelWidth: PanelWidth.NARROW,
             view: <div data-testid="subform" />,
           },
         ]}
@@ -90,4 +117,5 @@ test("can display a subform", async () => {
   );
   expect(screen.getByTestId("subform")).toBeInTheDocument();
   expect(screen.getByTestId(TestId.DEFAULT_VIEW)).toHaveClass("u-hide");
+  expect(setPanelWidth).toHaveBeenCalledWith(PanelWidth.NARROW);
 });

--- a/src/components/SubFormPanel/SubFormPanel.tsx
+++ b/src/components/SubFormPanel/SubFormPanel.tsx
@@ -1,10 +1,11 @@
 import { Col, Row } from "@canonical/react-components";
 import classNames from "classnames";
 import type { FormikValues } from "formik";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import EmbeddedPanel from "components/EmbeddedPanel";
 import PanelForm from "components/PanelForm";
+import type { PanelWidth } from "hooks/usePanel";
 
 import PanelFormLink from "./PanelFormLink";
 import PanelFormNavigation from "./PanelFormNavigation";
@@ -14,17 +15,30 @@ const SubFormPanel = <F extends FormikValues>({
   children,
   entity,
   isEditing,
+  panelWidth,
+  setPanelWidth,
   subForms,
   ...props
 }: Props<F>) => {
   const [view, setView] = useState<string | null>();
+  const changeView = (view: string | null, panelWidth?: PanelWidth | null) => {
+    setView(view);
+    setPanelWidth(panelWidth);
+  };
+
+  useEffect(() => {
+    // Set the width of the default form panel.
+    setPanelWidth(panelWidth);
+  }, [panelWidth, setPanelWidth]);
+
   return (
     <EmbeddedPanel
       title={
         <PanelFormNavigation
+          defaultPanelWidth={panelWidth}
           isEditing={isEditing}
           panelEntity={entity}
-          setView={setView}
+          setView={changeView}
           view={view}
         />
       }
@@ -47,14 +61,14 @@ const SubFormPanel = <F extends FormikValues>({
           </Row>
           <Row>
             <Col size={12}>
-              {subForms.map(({ count, entity, icon }) => (
+              {subForms.map(({ count, entity, icon, panelWidth }) => (
                 <PanelFormLink
                   entity={entity}
                   count={count}
                   icon={icon}
                   isEditing={isEditing}
                   key={entity}
-                  onClick={() => setView(entity)}
+                  onClick={() => changeView(entity, panelWidth)}
                 />
               ))}
             </Col>

--- a/src/components/SubFormPanel/types.ts
+++ b/src/components/SubFormPanel/types.ts
@@ -2,17 +2,21 @@ import type { FormikValues } from "formik";
 import type { ReactNode } from "react";
 
 import type { Props as PanelFormProps } from "components/PanelForm";
+import type { PanelWidth, SetPanelWidth } from "hooks/usePanel";
 
 export type SubForm = {
   count: number;
   entity: string;
   icon: string;
+  panelWidth?: PanelWidth;
   view: ReactNode;
 };
 
 export type Props<F extends FormikValues> = {
   entity: string;
   isEditing?: boolean;
+  panelWidth?: PanelWidth;
+  setPanelWidth: SetPanelWidth;
   subForms: SubForm[];
 } & Omit<PanelFormProps<F>, "submitLabel">;
 

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
@@ -50,7 +50,7 @@ afterAll(() => {
 
 // eslint-disable-next-line vitest/expect-expect
 test("should add a group", async () => {
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -68,7 +68,7 @@ test("should handle errors when adding groups", async () => {
       getPostGroupsResponseMock400({ message: "That group already exists" }),
     ),
   );
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -96,7 +96,7 @@ test("should add entitlements", async () => {
       patchDone = true;
     }
   });
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -168,7 +168,7 @@ test("should handle errors when adding entitlements", async () => {
     getPostGroupsMockHandler(mockGroupsData),
     getPatchGroupsIdEntitlementsMockHandler400(),
   );
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -244,7 +244,7 @@ test("should add users", async () => {
       patchDone = true;
     }
   });
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -295,7 +295,7 @@ test("should handle errors when adding users", async () => {
     getPatchGroupsIdEntitlementsMockHandler(),
     getPatchGroupsIdIdentitiesMockHandler400(),
   );
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -351,7 +351,7 @@ test("should add roles", async () => {
       postDone = true;
     }
   });
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -402,7 +402,7 @@ test("should handle errors when adding roles", async () => {
     getPatchGroupsIdEntitlementsMockHandler(),
     getPostGroupsIdRolesMockHandler400(),
   );
-  renderComponent(<AddGroupPanel close={vi.fn()} />);
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.tsx
@@ -17,7 +17,7 @@ import GroupPanel from "../GroupPanel";
 import { Label } from "./types";
 import type { Props } from "./types";
 
-const AddGroupPanel = ({ close }: Props) => {
+const AddGroupPanel = ({ close, setPanelWidth }: Props) => {
   const queryClient = useQueryClient();
   const {
     error: postGroupsError,
@@ -145,6 +145,7 @@ const AddGroupPanel = ({ close }: Props) => {
           ));
         });
       }}
+      setPanelWidth={setPanelWidth}
     />
   );
 };

--- a/src/components/pages/Groups/AddGroupPanel/types.ts
+++ b/src/components/pages/Groups/AddGroupPanel/types.ts
@@ -2,6 +2,7 @@ import type { Props as GroupPanelProps } from "../GroupPanel";
 
 export type Props = {
   close: GroupPanelProps["close"];
+  setPanelWidth: GroupPanelProps["setPanelWidth"];
 };
 
 export enum Label {

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -78,7 +78,9 @@ test("should add and remove entitlements", async () => {
       deleteDone = true;
     }
   });
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
   await act(
@@ -158,7 +160,9 @@ test("should handle errors when updating entitlements", async () => {
     getPatchGroupsIdEntitlementsMockHandler400(),
     getGetGroupsIdEntitlementsMockHandler400(),
   );
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
   await act(
@@ -244,7 +248,9 @@ test("should add and remove users", async () => {
       deleteDone = true;
     }
   });
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the users have loaded.
   await screen.findByText("2 users");
   await act(
@@ -297,7 +303,9 @@ test("should handle errors when updating users", async () => {
     getPatchGroupsIdIdentitiesMockHandler400(),
     getDeleteGroupsIdIdentitiesIdentityIdMockHandler400(),
   );
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the users have loaded.
   await screen.findByText("2 users");
   await act(

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
@@ -32,7 +32,7 @@ const generateError = (
   return null;
 };
 
-const EditGroupPanel = ({ close, groupId }: Props) => {
+const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
   const {
     error: getGroupsIdEntitlementsError,
     data: existingEntitlements,
@@ -178,6 +178,7 @@ const EditGroupPanel = ({ close, groupId }: Props) => {
         });
       }}
       groupId={groupId}
+      setPanelWidth={setPanelWidth}
     />
   );
 };

--- a/src/components/pages/Groups/EditGroupPanel/types.ts
+++ b/src/components/pages/Groups/EditGroupPanel/types.ts
@@ -3,6 +3,7 @@ import type { Props as GroupPanelProps } from "../GroupPanel";
 export type Props = {
   close: GroupPanelProps["close"];
   groupId: string;
+  setPanelWidth: GroupPanelProps["setPanelWidth"];
 };
 
 export enum Label {

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
@@ -13,7 +13,9 @@ import { Label } from "./types";
 
 test("can submit the form", async () => {
   const onSubmit = vi.fn();
-  renderComponent(<GroupPanel close={vi.fn()} onSubmit={onSubmit} />);
+  renderComponent(
+    <GroupPanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={onSubmit} />,
+  );
   await act(
     async () =>
       await userEvent.type(
@@ -26,13 +28,20 @@ test("can submit the form", async () => {
 
 test("the input is disabled when editing", async () => {
   renderComponent(
-    <GroupPanel close={vi.fn()} groupId="admin" onSubmit={vi.fn()} />,
+    <GroupPanel
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+      groupId="admin"
+      onSubmit={vi.fn()}
+    />,
   );
   expect(screen.getByRole("textbox", { name: Label.NAME })).toBeDisabled();
 });
 
 test("the entitlement form can be displayed", async () => {
-  renderComponent(<GroupPanel close={vi.fn()} onSubmit={vi.fn()} />);
+  renderComponent(
+    <GroupPanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={vi.fn()} />,
+  );
   await act(
     async () =>
       await userEvent.click(
@@ -45,7 +54,9 @@ test("the entitlement form can be displayed", async () => {
 });
 
 test("the user form can be displayed", async () => {
-  renderComponent(<GroupPanel close={vi.fn()} onSubmit={vi.fn()} />);
+  renderComponent(
+    <GroupPanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={vi.fn()} />,
+  );
   await act(
     async () =>
       await userEvent.click(screen.getByRole("button", { name: /Add users/ })),
@@ -56,7 +67,9 @@ test("the user form can be displayed", async () => {
 });
 
 test("the role form can be displayed", async () => {
-  renderComponent(<GroupPanel close={vi.fn()} onSubmit={vi.fn()} />);
+  renderComponent(
+    <GroupPanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={vi.fn()} />,
+  );
   await act(
     async () =>
       await userEvent.click(screen.getByRole("button", { name: /Add roles/ })),
@@ -70,6 +83,7 @@ test("submit button is disabled when editing and there are no changes", async ()
   renderComponent(
     <GroupPanel
       close={vi.fn()}
+      setPanelWidth={vi.fn()}
       existingEntitlements={[
         "can_edit::moderators:collection",
         "can_remove::staff:team",
@@ -85,6 +99,7 @@ test("submit button is enabled when editing and there are changes", async () => 
   renderComponent(
     <GroupPanel
       close={vi.fn()}
+      setPanelWidth={vi.fn()}
       existingEntitlements={[
         "can_edit::moderators:collection",
         "can_remove::staff:team",

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
@@ -5,6 +5,7 @@ import * as Yup from "yup";
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import EntitlementsPanelForm from "components/EntitlementsPanelForm";
 import SubFormPanel from "components/SubFormPanel";
+import { PanelWidth } from "hooks/usePanel";
 
 import IdentitiesPanelForm from "../IdentitiesPanelForm";
 import RolesPanelForm from "../RolesPanelForm";
@@ -63,6 +64,7 @@ const GroupPanel = ({
           removeRoles,
         )
       }
+      panelWidth={PanelWidth.DEFAULT}
       subForms={[
         {
           count:
@@ -107,6 +109,7 @@ const GroupPanel = ({
             removeEntitlements.length,
           entity: "entitlement",
           icon: "lock-locked",
+          panelWidth: PanelWidth.MEDIUM,
           view: isFetchingExistingEntitlements ? (
             <Spinner />
           ) : (

--- a/src/components/pages/Groups/GroupPanel/types.ts
+++ b/src/components/pages/Groups/GroupPanel/types.ts
@@ -1,5 +1,6 @@
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import type { Props as SubFormPanelProps } from "components/SubFormPanel";
+import type { SetPanelWidth } from "hooks/usePanel";
 
 export type FormFields = {
   id: string;
@@ -25,6 +26,7 @@ export type Props = {
     removeRoles?: string[],
   ) => Promise<void>;
   groupId?: string | null;
+  setPanelWidth: SetPanelWidth;
 };
 
 export enum Label {

--- a/src/components/pages/Groups/Groups.tsx
+++ b/src/components/pages/Groups/Groups.tsx
@@ -34,11 +34,15 @@ const Groups = () => {
   const { data, isFetching, isError, error, refetch } = useGetGroups();
   const { generatePanel, openPanel } = usePanel<{
     editGroupId?: string | null;
-  }>((closePanel, data) =>
+  }>((closePanel, data, setPanelWidth) =>
     data?.editGroupId ? (
-      <EditGroupPanel groupId={data.editGroupId} close={closePanel} />
+      <EditGroupPanel
+        groupId={data.editGroupId}
+        close={closePanel}
+        setPanelWidth={setPanelWidth}
+      />
     ) : (
-      <AddGroupPanel close={closePanel} />
+      <AddGroupPanel close={closePanel} setPanelWidth={setPanelWidth} />
     ),
   );
 

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.test.tsx
@@ -42,7 +42,7 @@ afterAll(() => {
 
 // eslint-disable-next-line vitest/expect-expect
 test("should add a role", async () => {
-  renderComponent(<AddRolePanel close={vi.fn()} />);
+  renderComponent(<AddRolePanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -67,7 +67,7 @@ test("should add a role and entitlements", async () => {
       done = true;
     }
   });
-  renderComponent(<AddRolePanel close={vi.fn()} />);
+  renderComponent(<AddRolePanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -140,7 +140,7 @@ test("should handle errors when adding roles", async () => {
       getPostRolesResponseMock400({ message: "That role already exists" }),
     ),
   );
-  renderComponent(<AddRolePanel close={vi.fn()} />);
+  renderComponent(<AddRolePanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(
@@ -164,7 +164,7 @@ test("should handle errors when adding entitlements", async () => {
       }),
     ),
   );
-  renderComponent(<AddRolePanel close={vi.fn()} />);
+  renderComponent(<AddRolePanel close={vi.fn()} setPanelWidth={vi.fn()} />);
   await act(
     async () =>
       await userEvent.type(

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
@@ -11,7 +11,7 @@ import RolePanel from "../RolePanel";
 
 import type { Props } from "./types";
 
-const AddRolePanel = ({ close }: Props) => {
+const AddRolePanel = ({ close, setPanelWidth }: Props) => {
   const queryClient = useQueryClient();
   const {
     error: postRolesError,
@@ -74,6 +74,7 @@ const AddRolePanel = ({ close }: Props) => {
           </ToastCard>
         ));
       }}
+      setPanelWidth={setPanelWidth}
     />
   );
 };

--- a/src/components/pages/Roles/AddRolePanel/types.ts
+++ b/src/components/pages/Roles/AddRolePanel/types.ts
@@ -2,4 +2,5 @@ import type { Props as RolePanelProps } from "../RolePanel";
 
 export type Props = {
   close: RolePanelProps["close"];
+  setPanelWidth: RolePanelProps["setPanelWidth"];
 };

--- a/src/components/pages/Roles/EditRolePanel/EditRolePanel.test.tsx
+++ b/src/components/pages/Roles/EditRolePanel/EditRolePanel.test.tsx
@@ -62,7 +62,9 @@ test("should add and remove entitlements", async () => {
       deleteDone = true;
     }
   });
-  renderComponent(<EditRolePanel roleId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditRolePanel roleId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
   await act(
@@ -142,7 +144,9 @@ test("should handle errors when updating entitlements", async () => {
     getPatchRolesIdEntitlementsMockHandler400(),
     getGetRolesIdEntitlementsMockHandler400(),
   );
-  renderComponent(<EditRolePanel roleId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditRolePanel roleId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
   await act(

--- a/src/components/pages/Roles/EditRolePanel/EditRolePanel.tsx
+++ b/src/components/pages/Roles/EditRolePanel/EditRolePanel.tsx
@@ -13,7 +13,7 @@ import RolePanel from "../RolePanel";
 
 import type { Props } from "./types";
 
-const EditRolePanel = ({ close, roleId }: Props) => {
+const EditRolePanel = ({ close, roleId, setPanelWidth }: Props) => {
   const {
     error: getRolesIdEntitlementsError,
     data: existingEntitlements,
@@ -97,6 +97,7 @@ const EditRolePanel = ({ close, roleId }: Props) => {
         });
       }}
       roleId={roleId}
+      setPanelWidth={setPanelWidth}
     />
   );
 };

--- a/src/components/pages/Roles/EditRolePanel/types.ts
+++ b/src/components/pages/Roles/EditRolePanel/types.ts
@@ -3,4 +3,5 @@ import type { Props as RolePanelProps } from "../RolePanel";
 export type Props = {
   close: RolePanelProps["close"];
   roleId: string;
+  setPanelWidth: RolePanelProps["setPanelWidth"];
 };

--- a/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.test.tsx
@@ -10,7 +10,9 @@ import { Label } from "./types";
 
 test("can submit the form", async () => {
   const onSubmit = vi.fn();
-  renderComponent(<RolePanel close={vi.fn()} onSubmit={onSubmit} />);
+  renderComponent(
+    <RolePanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={onSubmit} />,
+  );
   await act(
     async () =>
       await userEvent.type(
@@ -23,13 +25,20 @@ test("can submit the form", async () => {
 
 test("the input is disabled when editing", async () => {
   renderComponent(
-    <RolePanel close={vi.fn()} roleId="admin" onSubmit={vi.fn()} />,
+    <RolePanel
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+      roleId="admin"
+      onSubmit={vi.fn()}
+    />,
   );
   expect(screen.getByRole("textbox", { name: Label.NAME })).toBeDisabled();
 });
 
 test("the entitlement form can be displayed", async () => {
-  renderComponent(<RolePanel close={vi.fn()} onSubmit={vi.fn()} />);
+  renderComponent(
+    <RolePanel close={vi.fn()} setPanelWidth={vi.fn()} onSubmit={vi.fn()} />,
+  );
   await act(
     async () =>
       await userEvent.click(
@@ -45,6 +54,7 @@ test("submit button is disabled when editing and there are no changes", async ()
   renderComponent(
     <RolePanel
       close={vi.fn()}
+      setPanelWidth={vi.fn()}
       existingEntitlements={[
         "can_edit::moderators:collection",
         "can_remove::staff:team",
@@ -60,6 +70,7 @@ test("submit button is enabled when editing and there are changes", async () => 
   renderComponent(
     <RolePanel
       close={vi.fn()}
+      setPanelWidth={vi.fn()}
       existingEntitlements={[
         "can_edit::moderators:collection",
         "can_remove::staff:team",

--- a/src/components/pages/Roles/RolePanel/RolePanel.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.tsx
@@ -5,6 +5,7 @@ import * as Yup from "yup";
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import EntitlementsPanelForm from "components/EntitlementsPanelForm";
 import SubFormPanel from "components/SubFormPanel";
+import { PanelWidth } from "hooks/usePanel";
 
 import type { FormFields } from "./types";
 import { Label, type Props } from "./types";
@@ -16,9 +17,9 @@ const schema = Yup.object().shape({
 const RolePanel = ({
   existingEntitlements,
   isFetchingExisting,
-  roleId,
-  onSubmit,
   isSaving,
+  onSubmit,
+  roleId,
   ...props
 }: Props) => {
   const [addEntitlements, setAddEntitlements] = useState<Entitlement[]>([]);
@@ -37,6 +38,7 @@ const RolePanel = ({
       onSubmit={async (values) =>
         await onSubmit(values, addEntitlements, removeEntitlements)
       }
+      panelWidth={PanelWidth.DEFAULT}
       subForms={[
         {
           count:
@@ -45,6 +47,7 @@ const RolePanel = ({
             removeEntitlements.length,
           entity: "entitlement",
           icon: "lock-locked",
+          panelWidth: PanelWidth.MEDIUM,
           view: isFetchingExisting ? (
             <Spinner />
           ) : (

--- a/src/components/pages/Roles/RolePanel/types.ts
+++ b/src/components/pages/Roles/RolePanel/types.ts
@@ -1,5 +1,6 @@
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import type { Props as SubFormPanelProps } from "components/SubFormPanel";
+import type { SetPanelWidth } from "hooks/usePanel";
 
 export type FormFields = {
   id: string;
@@ -17,6 +18,7 @@ export type Props = {
     removeEntitlements?: Entitlement[],
   ) => Promise<void>;
   roleId?: string | null;
+  setPanelWidth: SetPanelWidth;
 };
 
 export enum Label {

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -34,11 +34,15 @@ const Roles = () => {
   const { data, isFetching, isError, error, refetch } = useGetRoles();
   const { generatePanel, openPanel } = usePanel<{
     editRoleId?: string | null;
-  }>((closePanel, data) =>
+  }>((closePanel, data, setPanelWidth) =>
     data?.editRoleId ? (
-      <EditRolePanel roleId={data.editRoleId} close={closePanel} />
+      <EditRolePanel
+        close={closePanel}
+        roleId={data.editRoleId}
+        setPanelWidth={setPanelWidth}
+      />
     ) : (
-      <AddRolePanel close={closePanel} />
+      <AddRolePanel close={closePanel} setPanelWidth={setPanelWidth} />
     ),
   );
 

--- a/src/hooks/usePanel.test.tsx
+++ b/src/hooks/usePanel.test.tsx
@@ -4,16 +4,23 @@ import userEvent from "@testing-library/user-event";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 import { renderComponent } from "test/utils";
 
-import { usePanel } from "./usePanel";
+import { PanelWidth, usePanel } from "./usePanel";
 
 const containerId = "portal-container";
 
 const TestComponent = () => {
   const { generatePanel, openPanel, closePanel } = usePanel<{
     state?: string | null;
-  }>((closePanel, data) => (
+  }>((closePanel, data, setPanelWidth) => (
     <div data-testid="panel">
       <button onClick={closePanel}>Exit</button>
+      <button
+        onClick={() => {
+          setPanelWidth(PanelWidth.NARROW);
+        }}
+      >
+        Change width
+      </button>
       {data?.state}
     </div>
   ));
@@ -39,6 +46,27 @@ test("opens the panel", async () => {
       await userEvent.click(screen.getByRole("button", { name: "Open" })),
   );
   expect(screen.getByTestId("panel")).toBeInTheDocument();
+});
+
+test("sets the panel width", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: containerId }}>
+      <div id={containerId}></div>
+      <TestComponent />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: "Open" })),
+  );
+  expect(document.getElementById(containerId)).not.toHaveClass("is-narrow");
+  await act(
+    async () =>
+      await userEvent.click(
+        screen.getByRole("button", { name: "Change width" }),
+      ),
+  );
+  expect(document.getElementById(containerId)).toHaveClass("is-narrow");
 });
 
 test("closes the panel", async () => {

--- a/src/hooks/usePanel.tsx
+++ b/src/hooks/usePanel.tsx
@@ -4,12 +4,26 @@ import { useCallback, useState } from "react";
 import { EmbeddedPanelLabelledById } from "components/EmbeddedPanel/consts";
 import { usePanelPortal } from "hooks/usePanelPortal";
 
+export enum PanelWidth {
+  MEDIUM = "is-medium",
+  NARROW = "is-narrow",
+  DEFAULT = "is-default",
+  WIDE = "is-wide",
+}
+
+export type SetPanelWidth = (panelWidth?: PanelWidth | null) => void;
+
 export const usePanel = <D extends object>(
-  getPanel: (closePanel: () => void, data: D | null) => ReactNode,
+  getPanel: (
+    closePanel: () => void,
+    data: D | null,
+    setPanelWidth: SetPanelWidth,
+  ) => ReactNode,
 ) => {
   const [data, setData] = useState<D | null>(null);
+  const [panelWidth, setPanelWidth] = useState<PanelWidth | null | undefined>();
   const { openPortal, closePortal, isOpen, Portal } = usePanelPortal(
-    "is-medium",
+    panelWidth,
     EmbeddedPanelLabelledById,
     { programmaticallyOpen: true },
   );
@@ -25,7 +39,9 @@ export const usePanel = <D extends object>(
     closePortal();
   }, [closePortal]);
   const generatePanel = useCallback(() => {
-    return isOpen ? <Portal>{getPanel(closePanel, data)}</Portal> : null;
+    return isOpen ? (
+      <Portal>{getPanel(closePanel, data, setPanelWidth)}</Portal>
+    ) : null;
   }, [Portal, closePanel, data, getPanel, isOpen]);
   return { generatePanel, openPanel, closePanel };
 };

--- a/src/hooks/usePanelPortal.ts
+++ b/src/hooks/usePanelPortal.ts
@@ -5,7 +5,7 @@ import usePortal from "react-useportal";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 
 export const usePanelPortal = (
-  className?: string,
+  className?: string | null,
   labelledBy?: string,
   options?: UsePortalOptions,
 ) => {


### PR DESCRIPTION
## Done

- Support the ability to change the panel width.
- Set a medium width only for the entitlements panel.

## QA

- Open the add roles or groups panel.
- Click on 'Add entitlements' and notice that the panel gets wider.
- Navigate back to the first screen and the panel should get narrower again.

## Details

https://warthogs.atlassian.net/browse/WD-10954