### PR TITLE
WD-10967 - feat: add empty states to panels

### DIFF
--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.test.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.test.tsx
@@ -7,6 +7,21 @@ import { hasNotification, renderComponent } from "test/utils";
 import EntitlementsPanelForm from "./EntitlementsPanelForm";
 import { Label } from "./types";
 
+test("displays the empty state", async () => {
+  renderComponent(
+    <EntitlementsPanelForm
+      addEntitlements={[]}
+      existingEntitlements={[]}
+      setAddEntitlements={vi.fn()}
+      removeEntitlements={[]}
+      setRemoveEntitlements={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: Label.EMPTY }),
+  ).toBeInTheDocument();
+});
+
 test("can add entitlements", async () => {
   const setAddEntitlements = vi.fn();
   renderComponent(

--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
@@ -15,6 +15,7 @@ import type { Column } from "react-table";
 import * as Yup from "yup";
 
 import FormikSubmitButton from "components/FormikSubmitButton";
+import NoEntityCard from "components/NoEntityCard";
 
 import type { Entitlement } from "./types";
 import { Label, type Props } from "./types";
@@ -192,31 +193,37 @@ const EntitlementsPanelForm = ({
       </Row>
       <Row>
         <Col size={12}>
-          <ModularTable
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            columns={COLUMN_DATA}
-            data={tableData}
-            emptyMsg="No entitlements have been added."
-          />
+          {tableData.length ? (
+            <ModularTable
+              getCellProps={({ column }) => {
+                switch (column.id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              getHeaderProps={({ id }) => {
+                switch (id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              columns={COLUMN_DATA}
+              data={tableData}
+            />
+          ) : (
+            <NoEntityCard
+              title={Label.EMPTY}
+              message="Add entitlements using the form above."
+            />
+          )}
         </Col>
       </Row>
     </>

--- a/src/components/EntitlementsPanelForm/types.ts
+++ b/src/components/EntitlementsPanelForm/types.ts
@@ -14,6 +14,7 @@ export type Props = {
 };
 
 export enum Label {
+  EMPTY = "No entitlements",
   ENTITLEMENT = "Entitlement",
   ENTITY = "Resource type",
   FORM = "Add entitlement",

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -375,7 +375,9 @@ test("should add and remove roles", async () => {
       deleteDone = true;
     }
   });
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the roles have loaded.
   await screen.findByText("2 roles");
   await act(
@@ -428,7 +430,9 @@ test("should handle errors when updating roles", async () => {
     getPostGroupsIdRolesMockHandler400(),
     getDeleteGroupsIdRolesRolesIdMockHandler(),
   );
-  renderComponent(<EditGroupPanel groupId="admin" close={vi.fn()} />);
+  renderComponent(
+    <EditGroupPanel groupId="admin" close={vi.fn()} setPanelWidth={vi.fn()} />,
+  );
   // Wait until the roles have loaded.
   await screen.findByText("2 roles");
   await act(

--- a/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.test.tsx
+++ b/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.test.tsx
@@ -7,6 +7,20 @@ import { hasNotification, renderComponent } from "test/utils";
 import IdentitiesPanelForm from "./IdentitiesPanelForm";
 import { Label } from "./types";
 
+test("displays the empty state", async () => {
+  renderComponent(
+    <IdentitiesPanelForm
+      addIdentities={[]}
+      setAddIdentities={vi.fn()}
+      removeIdentities={[]}
+      setRemoveIdentities={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: Label.EMPTY }),
+  ).toBeInTheDocument();
+});
+
 test("can add identities", async () => {
   const setAddIdentities = vi.fn();
   renderComponent(

--- a/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
+++ b/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
@@ -15,6 +15,7 @@ import type { Column } from "react-table";
 import * as Yup from "yup";
 
 import FormikSubmitButton from "components/FormikSubmitButton";
+import NoEntityCard from "components/NoEntityCard";
 
 import { Label, type Props } from "./types";
 
@@ -135,31 +136,37 @@ const IdentitiesPanelForm = ({
       </Row>
       <Row>
         <Col size={12}>
-          <ModularTable
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            columns={COLUMN_DATA}
-            data={tableData}
-            emptyMsg="No users have been added."
-          />
+          {tableData.length ? (
+            <ModularTable
+              getCellProps={({ column }) => {
+                switch (column.id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              getHeaderProps={({ id }) => {
+                switch (id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              columns={COLUMN_DATA}
+              data={tableData}
+            />
+          ) : (
+            <NoEntityCard
+              title={Label.EMPTY}
+              message="Add users using the form above."
+            />
+          )}
         </Col>
       </Row>
     </>

--- a/src/components/pages/Groups/IdentitiesPanelForm/types.ts
+++ b/src/components/pages/Groups/IdentitiesPanelForm/types.ts
@@ -8,6 +8,7 @@ export type Props = {
 };
 
 export enum Label {
+  EMPTY = "No users",
   USER = "Username",
   FORM = "Add user",
   REMOVE = "Remove user",

--- a/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.test.tsx
+++ b/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.test.tsx
@@ -7,6 +7,20 @@ import { hasNotification, renderComponent } from "test/utils";
 import RolesPanelForm from "./RolesPanelForm";
 import { Label } from "./types";
 
+test("displays the empty state", async () => {
+  renderComponent(
+    <RolesPanelForm
+      addRoles={[]}
+      setAddRoles={vi.fn()}
+      removeRoles={[]}
+      setRemoveRoles={vi.fn()}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: Label.EMPTY }),
+  ).toBeInTheDocument();
+});
+
 test("can add roles", async () => {
   const setAddRoles = vi.fn();
   renderComponent(

--- a/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
+++ b/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
@@ -15,6 +15,7 @@ import type { Column } from "react-table";
 import * as Yup from "yup";
 
 import FormikSubmitButton from "components/FormikSubmitButton";
+import NoEntityCard from "components/NoEntityCard";
 
 import { Label, type Props } from "./types";
 
@@ -124,31 +125,38 @@ const RolesPanelForm = ({
       </Row>
       <Row>
         <Col size={12}>
-          <ModularTable
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            columns={COLUMN_DATA}
-            data={tableData}
-            emptyMsg="No roles have been added."
-          />
+          {tableData.length ? (
+            <ModularTable
+              getCellProps={({ column }) => {
+                switch (column.id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              getHeaderProps={({ id }) => {
+                switch (id) {
+                  case "actions":
+                    return {
+                      className: "u-align--right",
+                    };
+                  default:
+                    return {};
+                }
+              }}
+              columns={COLUMN_DATA}
+              data={tableData}
+              emptyMsg="No roles have been added."
+            />
+          ) : (
+            <NoEntityCard
+              title={Label.EMPTY}
+              message="Add roles using the form above."
+            />
+          )}
         </Col>
       </Row>
     </>

--- a/src/components/pages/Groups/RolesPanelForm/types.ts
+++ b/src/components/pages/Groups/RolesPanelForm/types.ts
@@ -8,6 +8,7 @@ export type Props = {
 };
 
 export enum Label {
+  EMPTY = "No roles",
   ROLE = "Role name",
   FORM = "Add role",
   REMOVE = "Remove role",


### PR DESCRIPTION
## Done

- Display empty states inside the panel forms.

## QA

- Open the "Add group" panel.
- Click on each of the subforms and you should see the empty state for that form (currently with the icon on top until it gets updated in React Components).

## Details

https://warthogs.atlassian.net/browse/WD-10967
