### PR TITLE
WD-10993 - feat: only display errors on dirty forms

### DIFF
--- a/src/components/CleanFormikField/CleanFormikField.test.tsx
+++ b/src/components/CleanFormikField/CleanFormikField.test.tsx
@@ -1,0 +1,55 @@
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Form, Formik } from "formik";
+import { vi } from "vitest";
+import * as Yup from "yup";
+
+import { renderComponent } from "test/utils";
+
+import CleanFormikField from "./CleanFormikField";
+
+test("does not display errors when the form is not dirty", async () => {
+  const schema = Yup.object().shape({
+    resource: Yup.number().min(100, "Too small!"),
+  });
+  renderComponent(
+    <Formik
+      initialValues={{ resource: "notanumber" }}
+      onSubmit={vi.fn()}
+      validationSchema={schema}
+    >
+      <Form>
+        <CleanFormikField name="resource" type="number" />
+      </Form>
+    </Formik>,
+  );
+  const input = screen.getByRole("spinbutton");
+  await act(async () => {
+    await userEvent.type(input, "{tab}");
+  });
+  expect(input).not.toBeInvalid();
+  expect(input).not.toHaveAccessibleErrorMessage("Error: Too small!");
+});
+
+test("displays errors when the form is dirty", async () => {
+  const schema = Yup.object().shape({
+    resource: Yup.number().min(100, "Too small!"),
+  });
+  renderComponent(
+    <Formik
+      initialValues={{ resource: "" }}
+      onSubmit={vi.fn()}
+      validationSchema={schema}
+    >
+      <Form>
+        <CleanFormikField name="resource" type="number" />
+      </Form>
+    </Formik>,
+  );
+  const input = screen.getByRole("spinbutton");
+  await act(async () => {
+    await userEvent.type(input, "99{tab}");
+  });
+  expect(input).toBeInvalid();
+  expect(input).toHaveAccessibleErrorMessage("Error: Too small!");
+});

--- a/src/components/CleanFormikField/CleanFormikField.tsx
+++ b/src/components/CleanFormikField/CleanFormikField.tsx
@@ -1,0 +1,11 @@
+import { FormikField } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import { type Props } from "./types";
+
+const CleanFormikField = ({ ...props }: Props) => {
+  const { dirty } = useFormikContext();
+  return <FormikField {...props} displayError={dirty} />;
+};
+
+export default CleanFormikField;

--- a/src/components/CleanFormikField/index.ts
+++ b/src/components/CleanFormikField/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CleanFormikField";
+export * from "./types";

--- a/src/components/CleanFormikField/types.ts
+++ b/src/components/CleanFormikField/types.ts
@@ -1,0 +1,3 @@
+import type { FormikFieldProps } from "@canonical/react-components";
+
+export type Props = Omit<FormikFieldProps, "displayError">;

--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
@@ -3,7 +3,6 @@ import {
   Notification,
   NotificationSeverity,
   Row,
-  FormikField,
   ModularTable,
   Button,
   Icon,
@@ -14,6 +13,7 @@ import { useMemo } from "react";
 import type { Column } from "react-table";
 import * as Yup from "yup";
 
+import CleanFormikField from "components/CleanFormikField";
 import FormikSubmitButton from "components/FormikSubmitButton";
 import NoEntityCard from "components/NoEntityCard";
 
@@ -171,13 +171,17 @@ const EntitlementsPanelForm = ({
                   entitlements for this role.{" "}
                 </p>
                 <div className="entitlements-panel-form__fields">
-                  <FormikField label={Label.ENTITY} name="entity" type="text" />
-                  <FormikField
+                  <CleanFormikField
+                    label={Label.ENTITY}
+                    name="entity"
+                    type="text"
+                  />
+                  <CleanFormikField
                     label={Label.RESOURCE}
                     name="resource"
                     type="text"
                   />
-                  <FormikField
+                  <CleanFormikField
                     label={Label.ENTITLEMENT}
                     name="entitlement"
                     type="text"

--- a/src/components/PanelForm/PanelForm.test.tsx
+++ b/src/components/PanelForm/PanelForm.test.tsx
@@ -1,8 +1,8 @@
-import { FormikField } from "@canonical/react-components";
 import { screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
+import CleanFormikField from "components/CleanFormikField";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 import { hasNotification, renderComponent } from "test/utils";
 
@@ -69,7 +69,7 @@ test("can submit the form", async () => {
         onSubmit={onSubmit}
         submitLabel="Submit!"
       >
-        <FormikField label="name" name="name" type="text" />
+        <CleanFormikField label="name" name="name" type="text" />
       </PanelForm>
     </ReBACAdminContext.Provider>,
   );

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.tsx
@@ -1,7 +1,8 @@
-import { FormikField, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useState } from "react";
 import * as Yup from "yup";
 
+import CleanFormikField from "components/CleanFormikField";
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import EntitlementsPanelForm from "components/EntitlementsPanelForm";
 import SubFormPanel from "components/SubFormPanel";
@@ -125,7 +126,7 @@ const GroupPanel = ({
       ]}
       validationSchema={schema}
     >
-      <FormikField
+      <CleanFormikField
         disabled={isEditing}
         label={Label.NAME}
         name="id"

--- a/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
+++ b/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
@@ -3,7 +3,6 @@ import {
   Notification,
   NotificationSeverity,
   Row,
-  FormikField,
   ModularTable,
   Button,
   Icon,
@@ -14,6 +13,7 @@ import { useMemo } from "react";
 import type { Column } from "react-table";
 import * as Yup from "yup";
 
+import CleanFormikField from "components/CleanFormikField";
 import FormikSubmitButton from "components/FormikSubmitButton";
 import NoEntityCard from "components/NoEntityCard";
 
@@ -124,7 +124,11 @@ const IdentitiesPanelForm = ({
               <fieldset>
                 <h5>Add users</h5>
                 <div className="entitlements-panel-form__fields">
-                  <FormikField label={Label.USER} name="user" type="text" />
+                  <CleanFormikField
+                    label={Label.USER}
+                    name="user"
+                    type="text"
+                  />
                   <div className="entitlements-panel-form__submit">
                     <FormikSubmitButton>{Label.SUBMIT}</FormikSubmitButton>
                   </div>

--- a/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
+++ b/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
@@ -3,7 +3,6 @@ import {
   Notification,
   NotificationSeverity,
   Row,
-  FormikField,
   ModularTable,
   Button,
   Icon,
@@ -14,6 +13,7 @@ import { useMemo } from "react";
 import type { Column } from "react-table";
 import * as Yup from "yup";
 
+import CleanFormikField from "components/CleanFormikField";
 import FormikSubmitButton from "components/FormikSubmitButton";
 import NoEntityCard from "components/NoEntityCard";
 
@@ -113,7 +113,11 @@ const RolesPanelForm = ({
               <fieldset>
                 <h5>Add roles</h5>
                 <div className="entitlements-panel-form__fields">
-                  <FormikField label={Label.ROLE} name="roleName" type="text" />
+                  <CleanFormikField
+                    label={Label.ROLE}
+                    name="roleName"
+                    type="text"
+                  />
                   <div className="entitlements-panel-form__submit">
                     <FormikSubmitButton>{Label.SUBMIT}</FormikSubmitButton>
                   </div>

--- a/src/components/pages/Roles/RolePanel/RolePanel.tsx
+++ b/src/components/pages/Roles/RolePanel/RolePanel.tsx
@@ -1,7 +1,8 @@
-import { FormikField, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useState } from "react";
 import * as Yup from "yup";
 
+import CleanFormikField from "components/CleanFormikField";
 import type { Entitlement } from "components/EntitlementsPanelForm";
 import EntitlementsPanelForm from "components/EntitlementsPanelForm";
 import SubFormPanel from "components/SubFormPanel";
@@ -63,7 +64,7 @@ const RolePanel = ({
       ]}
       validationSchema={schema}
     >
-      <FormikField
+      <CleanFormikField
         disabled={isEditing}
         label={Label.NAME}
         name="id"


### PR DESCRIPTION
## Done

- Display errors only when the form is dirty. This is to prevent the buttons jumping when you click outside a field and haven't entered anything.

## QA

- Go to the group panel
- click on entitlements and notice that the screen doesn't jump
- click inside a field and then outside and the validation shouldn't appear.
- Enter something in a field and notice that the validation will appear if you click in then outside of another field.

## Details

https://warthogs.atlassian.net/browse/WD-10993