### PR TITLE
WD-12970 - fix: display panels when there is no data

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
       - name: Install dependencies
         run: |
           sudo chmod -R 777 .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/rebac-admin",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.4",
   "description": "A shared UI for managing ReBAC/OpenFGA permissions",
   "repository": "git@github.com:canonical/rebac-admin.git",
   "author": "Canonical Webteam",

--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -93,6 +93,26 @@ test("should display error notification and refetch data", async () => {
   expect(rows).toHaveLength(4);
 });
 
+test("displays the add panel", async () => {
+  mockApiServer.use(
+    getGetGroupsMockHandler(getGetGroupsResponseMock({ data: [] })),
+  );
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
+      <aside id="aside-panel"></aside>
+      <Groups />
+    </ReBACAdminContext.Provider>,
+  );
+  await act(
+    async () =>
+      await userEvent.click(screen.getByRole("button", { name: Label.ADD })),
+  );
+  const panel = await screen.findByRole("complementary", {
+    name: "Create group",
+  });
+  expect(panel).toBeInTheDocument();
+});
+
 test("displays the edit panel", async () => {
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>

--- a/src/components/pages/Groups/Groups.tsx
+++ b/src/components/pages/Groups/Groups.tsx
@@ -142,7 +142,7 @@ const Groups = () => {
 
   const generateCreateGroupButton = () => (
     <Button appearance={ButtonAppearance.POSITIVE} onClick={openPanel}>
-      Create group
+      {Label.ADD}
     </Button>
   );
 
@@ -167,42 +167,39 @@ const Groups = () => {
       );
     } else {
       return (
-        <>
-          <ModularTable
-            columns={columns}
-            data={tableData}
-            emptyMsg={Label.NO_GROUPS}
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "selectGroup":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "selectGroup":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-          />
-          {generatePanel()}
-        </>
+        <ModularTable
+          columns={columns}
+          data={tableData}
+          emptyMsg={Label.NO_GROUPS}
+          getCellProps={({ column }) => {
+            switch (column.id) {
+              case "selectGroup":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+          getHeaderProps={({ id }) => {
+            switch (id) {
+              case "selectGroup":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+        />
       );
     }
   };
@@ -224,6 +221,7 @@ const Groups = () => {
       title="Groups"
     >
       {generateContent()}
+      {generatePanel()}
     </Content>
   );
 };

--- a/src/components/pages/Groups/types.ts
+++ b/src/components/pages/Groups/types.ts
@@ -1,4 +1,5 @@
 export enum Label {
+  ADD = "Create group",
   ACTION_MENU = "Action menu",
   EDIT = "Edit",
   DELETE = "Delete",

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -90,6 +90,9 @@ test("should display error notification and refetch data", async () => {
 });
 
 test("displays the add panel", async () => {
+  mockApiServer.use(
+    getGetRolesMockHandler(getGetRolesResponseMock({ data: [] })),
+  );
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
       <aside id="aside-panel"></aside>

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -101,9 +101,7 @@ test("displays the add panel", async () => {
   );
   await act(
     async () =>
-      await userEvent.click(
-        screen.getByRole("button", { name: "Create role" }),
-      ),
+      await userEvent.click(screen.getByRole("button", { name: Label.ADD })),
   );
   const panel = await screen.findByRole("complementary", {
     name: "Create role",

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -165,42 +165,39 @@ const Roles = () => {
       );
     } else {
       return (
-        <>
-          <ModularTable
-            columns={columns}
-            data={tableData}
-            emptyMsg={Label.NO_ROLES}
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "selectRole":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "selectRole":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-          />
-          {generatePanel()}
-        </>
+        <ModularTable
+          columns={columns}
+          data={tableData}
+          emptyMsg={Label.NO_ROLES}
+          getCellProps={({ column }) => {
+            switch (column.id) {
+              case "selectRole":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+          getHeaderProps={({ id }) => {
+            switch (id) {
+              case "selectRole":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+        />
       );
     }
   };
@@ -222,6 +219,7 @@ const Roles = () => {
       title="Roles"
     >
       {generateContent()}
+      {generatePanel()}
     </Content>
   );
 };

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -140,7 +140,7 @@ const Roles = () => {
 
   const generateCreateRoleButton = () => (
     <Button appearance={ButtonAppearance.POSITIVE} onClick={openPanel}>
-      Create role
+      {Label.ADD}
     </Button>
   );
 

--- a/src/components/pages/Roles/types.ts
+++ b/src/components/pages/Roles/types.ts
@@ -1,4 +1,5 @@
 export enum Label {
+  ADD = "Create role",
   ACTION_MENU = "Action menu",
   EDIT = "Edit",
   DELETE = "Delete",


### PR DESCRIPTION
## Done

- Fix panels that were not displayed if there was no data.

## QA

- View the roles and groups pages with no roles/groups data and check that you can open the "add" panels.

## Details

https://warthogs.atlassian.net/browse/WD-12970
