### PR TITLE
WD-12971 - fix: display panels when there is no data

### DIFF
--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -103,6 +103,9 @@ test("should display error notification and refetch data", async () => {
 });
 
 test("displays the add panel", async () => {
+  mockApiServer.use(
+    getGetGroupsMockHandler(getGetGroupsResponseMock({ data: [] })),
+  );
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
       <aside id="aside-panel"></aside>

--- a/src/components/pages/Groups/Groups.tsx
+++ b/src/components/pages/Groups/Groups.tsx
@@ -168,42 +168,39 @@ const Groups = () => {
       );
     } else {
       return (
-        <>
-          <ModularTable
-            columns={columns}
-            data={tableData}
-            emptyMsg={Label.NO_GROUPS}
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "selectGroup":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "selectGroup":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-          />
-          {generatePanel()}
-        </>
+        <ModularTable
+          columns={columns}
+          data={tableData}
+          emptyMsg={Label.NO_GROUPS}
+          getCellProps={({ column }) => {
+            switch (column.id) {
+              case "selectGroup":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+          getHeaderProps={({ id }) => {
+            switch (id) {
+              case "selectGroup":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+        />
       );
     }
   };
@@ -226,6 +223,7 @@ const Groups = () => {
       title="Groups"
     >
       {generateContent()}
+      {generatePanel()}
     </Content>
   );
 };

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -99,6 +99,9 @@ test("should display error notification and refetch data", async () => {
 });
 
 test("displays the add panel", async () => {
+  mockApiServer.use(
+    getGetRolesMockHandler(getGetRolesResponseMock({ data: [] })),
+  );
   renderComponent(
     <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
       <aside id="aside-panel"></aside>

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -165,42 +165,39 @@ const Roles = () => {
       );
     } else {
       return (
-        <>
-          <ModularTable
-            columns={columns}
-            data={tableData}
-            emptyMsg={Label.NO_ROLES}
-            getCellProps={({ column }) => {
-              switch (column.id) {
-                case "selectRole":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-            getHeaderProps={({ id }) => {
-              switch (id) {
-                case "selectRole":
-                  return {
-                    className: "select-entity-checkbox",
-                  };
-                case "actions":
-                  return {
-                    className: "u-align--right",
-                  };
-                default:
-                  return {};
-              }
-            }}
-          />
-          {generatePanel()}
-        </>
+        <ModularTable
+          columns={columns}
+          data={tableData}
+          emptyMsg={Label.NO_ROLES}
+          getCellProps={({ column }) => {
+            switch (column.id) {
+              case "selectRole":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+          getHeaderProps={({ id }) => {
+            switch (id) {
+              case "selectRole":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+        />
       );
     }
   };
@@ -223,6 +220,7 @@ const Roles = () => {
       title="Roles"
     >
       {generateContent()}
+      {generatePanel()}
     </Content>
   );
 };


### PR DESCRIPTION
## Done

- Fix roles and groups panels where there is no data.

## QA

- Go to the roles and groups pages when you have no roles or groups and check that you can open the "add" panel.

## Details

https://warthogs.atlassian.net/browse/WD-12971
