### PR TITLE
WD-12381 - feat: add api proxy

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -4,6 +4,7 @@
 
 - [Development setup](#development-setup)
 - [Develop with external API](#develop-with-external-api)
+  - [Proxied requests](#proxied-requests)
 - [Testing in host projects](#testing-in-host-projects)
 - [Serving mock API](#serving-mock-api)
 - [Download openapi.yaml](#download-openapiyaml)
@@ -45,6 +46,21 @@ variables:
 ```
 VITE_DEMO_API_MOCKED=false
 VITE_DEMO_API_URL=http://example.com/api
+```
+
+### Proxied requests
+
+When working with the production API you may need to proxy requests to prevent
+CORS errors.
+
+To do this you will need to set the server address to proxy requests to:
+
+```
+VITE_DEMO_API_MOCKED=false
+# Set the API URL to the path that the API is served on:
+VITE_DEMO_API_URL=/api/v0
+# Set the proxy URL to the address of the API server:
+VITE_DEMO_PROXY_API_URL=http://1.2.3.4:1234/
 ```
 
 ## Testing in host projects

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,11 @@ export default defineConfig(({ mode }) => {
     server: {
       host: "0.0.0.0",
       port: Number(env.PORT),
+      proxy: {
+        [env.VITE_DEMO_API_URL ?? "/api"]: {
+          target: env.VITE_DEMO_PROXY_API_URL ?? "/",
+        },
+      },
     },
     test: {
       coverage: {


### PR DESCRIPTION
## Done

- Add a proxy to get around CORS errors.

## QA
Note: this PR is required to be able to add data: https://github.com/canonical/rebac-admin/pull/125.
- Set your `.env.local` to point to the API. Something like this:
```
VITE_DEMO_API_MOCKED=false
VITE_DEMO_PROXY_API_URL=http://<admin-api-ip>:9999/
VITE_DEMO_API_URL=/rebac/v1/
```
- Open rebac-admin
- Check that it loads data from the API, if you have no data you can use the forms to add roles/groups.

## Details

https://warthogs.atlassian.net/browse/WD-12381
