### PR TITLE
WD-12391 - feat: delete users panel

### DIFF
--- a/src/components/SubFormPanel/index.ts
+++ b/src/components/SubFormPanel/index.ts
@@ -1,2 +1,3 @@
 export { default } from "./SubFormPanel";
 export * from "./types";
+export type { Props as SubFormPanelProps } from "./types";

--- a/src/components/pages/Users/DeleteUsersPanel/DeleteUsersPanel.test.tsx
+++ b/src/components/pages/Users/DeleteUsersPanel/DeleteUsersPanel.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupServer } from "msw/node";
+import { vi } from "vitest";
+
+import {
+  getDeleteIdentitiesItemMockHandler,
+  getDeleteIdentitiesItemMockHandler400,
+  getDeleteIdentitiesItemResponseMock400,
+} from "api/identities/identities.msw";
+import { DeleteEntityPanelLabel } from "components/DeleteEntityPanel";
+import { renderComponent, hasToast } from "test/utils";
+
+import DeleteUsersPanel from "./DeleteUsersPanel";
+import { Label as DeleteUsersPanelLabel } from "./types";
+
+const mockApiServer = setupServer(getDeleteIdentitiesItemMockHandler());
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+test("should delete identities", async () => {
+  renderComponent(
+    <DeleteUsersPanel identities={["user1", "user2"]} close={vi.fn()} />,
+  );
+  const textBoxes = screen.getAllByRole("textbox");
+  expect(textBoxes).toHaveLength(1);
+  const confirmationMessageTextBox = textBoxes[0];
+  await userEvent.type(confirmationMessageTextBox, "remove 2 users");
+  await userEvent.click(screen.getByText(DeleteEntityPanelLabel.DELETE));
+  await hasToast(DeleteUsersPanelLabel.DEELTE_SUCCESS_MESSAGE, "positive");
+});
+
+test("should handle errors when deleting identities", async () => {
+  mockApiServer.use(
+    getDeleteIdentitiesItemMockHandler400(
+      getDeleteIdentitiesItemResponseMock400({ message: "Can't remove user" }),
+    ),
+  );
+  renderComponent(<DeleteUsersPanel identities={["user1"]} close={vi.fn()} />);
+  const textBoxes = screen.getAllByRole("textbox");
+  expect(textBoxes).toHaveLength(1);
+  const confirmationMessageTextBox = textBoxes[0];
+  await userEvent.type(confirmationMessageTextBox, "remove 1 user");
+  await userEvent.click(screen.getByText(DeleteEntityPanelLabel.DELETE));
+  await hasToast(DeleteUsersPanelLabel.DELETE_ERROR_MESSAGE, "negative");
+});

--- a/src/components/pages/Users/DeleteUsersPanel/DeleteUsersPanel.tsx
+++ b/src/components/pages/Users/DeleteUsersPanel/DeleteUsersPanel.tsx
@@ -1,0 +1,67 @@
+import { useQueryClient } from "@tanstack/react-query";
+import Limiter from "async-limiter";
+import reactHotToast from "react-hot-toast";
+
+import { useDeleteIdentitiesItem } from "api/identities/identities";
+import DeleteEntityPanel from "components/DeleteEntityPanel";
+import ToastCard from "components/ToastCard";
+import { API_CONCURRENCY } from "consts";
+import { Endpoint } from "types/api";
+
+import { Label, type Props } from "./types";
+
+const DeleteUsersPanel = ({ identities, close }: Props) => {
+  const queryClient = useQueryClient();
+  const {
+    mutateAsync: deleteIdentitiesId,
+    isPending: isDeleteIdentitiesIdPending,
+  } = useDeleteIdentitiesItem();
+
+  const handleDeleteIdentities = async () => {
+    let hasError = false;
+    const queue = new Limiter({ concurrency: API_CONCURRENCY });
+    identities.forEach((id) => {
+      queue.push(async (done) => {
+        try {
+          await deleteIdentitiesId({
+            id,
+          });
+        } catch (error) {
+          hasError = true;
+        }
+        done();
+      });
+    });
+    queue.onDone(() => {
+      void queryClient.invalidateQueries({
+        queryKey: [Endpoint.IDENTITIES],
+      });
+      close();
+      if (hasError) {
+        reactHotToast.custom((t) => (
+          <ToastCard toastInstance={t} type="negative">
+            {Label.DELETE_ERROR_MESSAGE}
+          </ToastCard>
+        ));
+      } else {
+        reactHotToast.custom((t) => (
+          <ToastCard toastInstance={t} type="positive">
+            {Label.DEELTE_SUCCESS_MESSAGE}
+          </ToastCard>
+        ));
+      }
+    });
+  };
+
+  return (
+    <DeleteEntityPanel
+      entity="user"
+      count={identities.length}
+      onDelete={handleDeleteIdentities}
+      isDeletePending={isDeleteIdentitiesIdPending}
+      close={close}
+    />
+  );
+};
+
+export default DeleteUsersPanel;

--- a/src/components/pages/Users/DeleteUsersPanel/index.ts
+++ b/src/components/pages/Users/DeleteUsersPanel/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DeleteUsersPanel";
+export * from "./types";

--- a/src/components/pages/Users/DeleteUsersPanel/types.ts
+++ b/src/components/pages/Users/DeleteUsersPanel/types.ts
@@ -1,0 +1,13 @@
+import type { Identity } from "api/api.schemas";
+
+import type { UserPanelProps } from "../UserPanel";
+
+export type Props = {
+  identities: NonNullable<Identity["id"]>[];
+  close: UserPanelProps["close"];
+};
+
+export enum Label {
+  DELETE_ERROR_MESSAGE = "Some users couldn't be deleted",
+  DEELTE_SUCCESS_MESSAGE = "Selected users have been deleted",
+}

--- a/src/components/pages/Users/UserPanel/index.ts
+++ b/src/components/pages/Users/UserPanel/index.ts
@@ -1,0 +1,1 @@
+export type { Props as UserPanelProps } from "./types";

--- a/src/components/pages/Users/UserPanel/types.ts
+++ b/src/components/pages/Users/UserPanel/types.ts
@@ -1,0 +1,6 @@
+import type { SubFormPanelProps } from "components/SubFormPanel";
+
+export type Props = {
+  // TODO: set the correct form types once this component has been implemented.
+  close: SubFormPanelProps<{}>["close"];
+};

--- a/src/components/pages/Users/Users.test.tsx
+++ b/src/components/pages/Users/Users.test.tsx
@@ -19,6 +19,7 @@ import { Label, Label as UsersLabel } from "./types";
 const mockUserData = getGetIdentitiesResponseMock({
   data: [
     getGetIdentitiesItemResponseMock({
+      id: "user1",
       addedBy: "within",
       email: "pfft",
       firstName: "really",

--- a/src/components/pages/Users/Users.test.tsx
+++ b/src/components/pages/Users/Users.test.tsx
@@ -8,12 +8,13 @@ import {
   getGetIdentitiesResponseMock,
 } from "api/identities/identities.msw";
 import { Label as CheckCapabilityLabel } from "components/CheckCapability";
+import { ReBACAdminContext } from "context/ReBACAdminContext";
 import { getGetActualCapabilitiesMock } from "mocks/capabilities";
 import { getGetIdentitiesErrorMockHandler } from "mocks/identities";
 import { renderComponent } from "test/utils";
 
 import Users from "./Users";
-import { Label as UsersLabel } from "./types";
+import { Label, Label as UsersLabel } from "./types";
 
 const mockUserData = getGetIdentitiesResponseMock({
   data: [
@@ -52,18 +53,18 @@ test("should display spinner on mount", () => {
 test("should display correct user data after fetching users", async () => {
   renderComponent(<Users />);
   const columnHeaders = await screen.findAllByRole("columnheader");
-  expect(columnHeaders).toHaveLength(5);
+  expect(columnHeaders).toHaveLength(7);
   const rows = screen.getAllByRole("row");
   // The first row contains the column headers and the next 7 rows contain
   // user data.
   expect(rows).toHaveLength(8);
   const firstUserCells = within(rows[1]).getAllByRole("cell");
-  expect(firstUserCells).toHaveLength(5);
-  expect(firstUserCells[0]).toHaveTextContent("really");
-  expect(firstUserCells[1]).toHaveTextContent("Unknown");
-  expect(firstUserCells[2]).toHaveTextContent("within");
-  expect(firstUserCells[3]).toHaveTextContent("pfft");
-  expect(firstUserCells[4]).toHaveTextContent("noteworthy");
+  expect(firstUserCells).toHaveLength(7);
+  expect(firstUserCells[1]).toHaveTextContent("really");
+  expect(firstUserCells[2]).toHaveTextContent("Unknown");
+  expect(firstUserCells[3]).toHaveTextContent("within");
+  expect(firstUserCells[4]).toHaveTextContent("pfft");
+  expect(firstUserCells[5]).toHaveTextContent("noteworthy");
 });
 
 test("should display no users data when no users are available", async () => {
@@ -99,4 +100,20 @@ test("should display error notification and refetch data", async () => {
   ).toBeInTheDocument();
   const rows = await screen.findAllByRole("row");
   expect(rows).toHaveLength(7);
+});
+
+test("displays the delete panel", async () => {
+  renderComponent(
+    <ReBACAdminContext.Provider value={{ asidePanelId: "aside-panel" }}>
+      <aside id="aside-panel"></aside>
+      <Users />
+    </ReBACAdminContext.Provider>,
+  );
+  const rows = await screen.findAllByRole("row");
+  await userEvent.click(within(rows[1]).getByRole("checkbox"));
+  await userEvent.click(screen.getByRole("button", { name: Label.DELETE }));
+  const panel = await screen.findByRole("complementary", {
+    name: "Delete 1 user",
+  });
+  expect(panel).toBeInTheDocument();
 });

--- a/src/components/pages/Users/Users.tsx
+++ b/src/components/pages/Users/Users.tsx
@@ -1,11 +1,23 @@
-import { ModularTable, Spinner } from "@canonical/react-components";
+import {
+  ModularTable,
+  Spinner,
+  CheckboxInput,
+  ContextualMenu,
+  Icon,
+  Button,
+  ButtonAppearance,
+} from "@canonical/react-components";
+import type { ReactNode } from "react";
 import { useMemo, type JSX } from "react";
 
+import type { Identity } from "api/api.schemas";
 import { useGetIdentities } from "api/identities/identities";
 import Content from "components/Content";
 import ErrorNotification from "components/ErrorNotification";
+import { usePanel, useEntitiesSelect } from "hooks";
 import { Endpoint } from "types/api";
 
+import DeleteUsersPanel from "./DeleteUsersPanel";
 import { Label } from "./types";
 
 const COLUMN_DATA = [
@@ -29,25 +41,130 @@ const COLUMN_DATA = [
     Header: "source",
     accessor: "source",
   },
+  {
+    Header: "actions",
+    accessor: "actions",
+  },
 ];
 
 const Users = () => {
   const { data, isFetching, isError, error, refetch } = useGetIdentities();
+  const { generatePanel, openPanel, isPanelOpen } = usePanel<{
+    editIdentityId?: string | null;
+    deleteIdentities?: NonNullable<Identity["id"]>[];
+  }>((closePanel, data) => {
+    if (data?.editIdentityId) {
+      // TODO: Edit user panel.
+    } else if (data?.deleteIdentities) {
+      return (
+        <DeleteUsersPanel
+          identities={data.deleteIdentities}
+          close={closePanel}
+        />
+      );
+    } else {
+      // TODO: Add user panel.
+    }
+  });
 
-  const tableData = useMemo<Record<string, string>[]>(() => {
+  const {
+    handleSelectEntity: handleSelectIdentity,
+    handleSelectAllEntities: handleSelectAllIdentities,
+    selectedEntities: selectedIdentities,
+    areAllEntitiesSelected: areAllIdentitiesSelected,
+  } = useEntitiesSelect(
+    data?.data.data.reduce<NonNullable<Identity["id"]>[]>((ids, { id }) => {
+      if (id) {
+        ids.push(id);
+      }
+      return ids;
+    }, []) ?? [],
+  );
+
+  const tableData = useMemo<Record<string, ReactNode>[]>(() => {
     const users = data?.data.data;
     if (!users) {
       return [];
     }
     const tableData = users.map((user) => ({
+      selectIdentity: (
+        <CheckboxInput
+          label=""
+          inline
+          checked={
+            areAllIdentitiesSelected ||
+            (!!user.id && selectedIdentities.includes(user.id))
+          }
+          onChange={() => user.id && handleSelectIdentity(user.id)}
+          disabled={isPanelOpen}
+        />
+      ),
       firstName: user?.firstName ?? "Unknown",
       lastName: user?.lastName ?? "Unknown",
       addedBy: user.addedBy,
       email: user.email,
       source: user.source,
+      actions: (
+        <ContextualMenu
+          links={[
+            {
+              appearance: "link",
+              children: (
+                <>
+                  <Icon name="edit" /> {Label.EDIT}
+                </>
+              ),
+              onClick: () => {
+                openPanel({ editIdentityId: user.id });
+              },
+            },
+            {
+              appearance: "link",
+              children: (
+                <>
+                  <Icon name="delete" /> {Label.DELETE}
+                </>
+              ),
+              onClick: () =>
+                user.id && openPanel({ deleteIdentities: [user.id] }),
+            },
+          ]}
+          position="right"
+          scrollOverflow
+          toggleAppearance="base"
+          toggleClassName="has-icon u-no-margin--bottom is-small"
+          toggleLabel={<Icon name="menu">{Label.ACTION_MENU}</Icon>}
+        />
+      ),
     }));
     return tableData;
-  }, [data]);
+  }, [
+    areAllIdentitiesSelected,
+    data?.data.data,
+    handleSelectIdentity,
+    isPanelOpen,
+    openPanel,
+    selectedIdentities,
+  ]);
+
+  const columns = [
+    {
+      Header: (
+        <CheckboxInput
+          label=""
+          inline
+          checked={areAllIdentitiesSelected}
+          indeterminate={
+            !areAllIdentitiesSelected && !!selectedIdentities.length
+          }
+          onChange={handleSelectAllIdentities}
+          disabled={isPanelOpen}
+        />
+      ),
+      accessor: "selectIdentity",
+    },
+    ...COLUMN_DATA,
+  ];
 
   const generateContent = (): JSX.Element => {
     if (isFetching) {
@@ -64,17 +181,60 @@ const Users = () => {
       return (
         <ModularTable
           className="audit-logs-table"
-          columns={COLUMN_DATA}
+          columns={columns}
           data={tableData}
           emptyMsg={Label.NO_USERS}
+          getCellProps={({ column }) => {
+            switch (column.id) {
+              case "selectIdentity":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
+          getHeaderProps={({ id }) => {
+            switch (id) {
+              case "selectIdentity":
+                return {
+                  className: "select-entity-checkbox",
+                };
+              case "actions":
+                return {
+                  className: "u-align--right",
+                };
+              default:
+                return {};
+            }
+          }}
         />
       );
     }
   };
 
   return (
-    <Content title="Users" endpoint={Endpoint.IDENTITIES}>
+    <Content
+      controls={
+        <>
+          <Button
+            appearance={ButtonAppearance.NEGATIVE}
+            disabled={!selectedIdentities.length}
+            onClick={() => openPanel({ deleteIdentities: selectedIdentities })}
+          >
+            {Label.DELETE}
+          </Button>
+        </>
+      }
+      title="Users"
+      endpoint={Endpoint.IDENTITIES}
+    >
       {generateContent()}
+      {generatePanel()}
     </Content>
   );
 };

--- a/src/components/pages/Users/types.ts
+++ b/src/components/pages/Users/types.ts
@@ -1,4 +1,7 @@
 export enum Label {
+  ACTION_MENU = "Action menu",
+  DELETE = "Delete",
+  EDIT = "Edit",
   FETCHING_USERS = "Fetching users data...",
   FETCHING_USERS_ERROR = "Couldn't fetch user data.",
   NO_USERS = "No users found!",


### PR DESCRIPTION
## Done

- Add support for deleting users.

## QA

- Go to the users panel and check that you can open the delete panel.
Note: the checkboxes don't currently work with the mock API as the ID is not generated from the mocks. I've asked about how to handle deleting a user if the id is not defined (this is an issue that's not specific to identities).

## Details

https://warthogs.atlassian.net/browse/WD-12391
