### PR TITLE
WD-13045 - refactor: use ids for operating on entities

### DIFF
--- a/src/components/CleanFormikField/CleanFormikField.tsx
+++ b/src/components/CleanFormikField/CleanFormikField.tsx
@@ -1,11 +1,17 @@
+import type { Input, FormikFieldProps } from "@canonical/react-components";
 import { FormikField } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import type { ComponentType, ElementType } from "react";
 
-import { type Props } from "./types";
-
-const CleanFormikField = ({ ...props }: Props) => {
+const CleanFormikField = <
+  C extends ElementType | ComponentType = typeof Input,
+>({
+  ...props
+}: FormikFieldProps<C>) => {
   const { dirty } = useFormikContext();
-  return <FormikField {...props} displayError={dirty} />;
+  return (
+    <FormikField<C> {...props} displayError={props.displayError ?? dirty} />
+  );
 };
 
 export default CleanFormikField;

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
@@ -16,6 +16,14 @@ import {
   getPatchGroupsItemRolesMockHandler,
   getPatchGroupsItemRolesMockHandler400,
 } from "api/groups/groups.msw";
+import {
+  getGetIdentitiesMockHandler,
+  getGetIdentitiesResponseMock,
+} from "api/identities/identities.msw";
+import {
+  getGetRolesMockHandler,
+  getGetRolesResponseMock,
+} from "api/roles/roles.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
 import { hasNotification, hasToast, renderComponent } from "test/utils";
 
@@ -31,6 +39,23 @@ const mockGroupsData = getPostGroupsResponseMock({
   name: "group1",
 });
 const mockApiServer = setupServer(
+  getGetIdentitiesMockHandler(
+    getGetIdentitiesResponseMock({
+      data: [
+        { id: "user1", email: "user1@example.com" },
+        { id: "user2", email: "user2@example.com" },
+      ],
+    }),
+  ),
+  getGetRolesMockHandler(
+    getGetRolesResponseMock({
+      data: [
+        { id: "role123", name: "role1" },
+        { id: "role234", name: "role2" },
+        { id: "role345", name: "role3" },
+      ],
+    }),
+  ),
   getPostGroupsMockHandler(mockGroupsData),
   getPatchGroupsItemEntitlementsMockHandler(),
   getPatchGroupsItemIdentitiesMockHandler(),
@@ -211,11 +236,15 @@ test("should add users", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add users/ }));
-  await userEvent.type(
-    screen.getByRole("textbox", {
+  // Wait for the options to load.
+  await screen.findByRole("option", {
+    name: "user2@example.com",
+  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
       name: IdentitiesPanelFormLabel.USER,
     }),
-    "joe",
+    "user2@example.com",
   );
   await userEvent.click(
     screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
@@ -225,7 +254,9 @@ test("should add users", async () => {
   );
   await userEvent.click(screen.getByRole("button", { name: "Create group" }));
   await waitFor(() => expect(patchDone).toBeTruthy());
-  expect(patchResponseBody).toBe('{"patches":[{"identity":"joe","op":"add"}]}');
+  expect(patchResponseBody).toBe(
+    '{"patches":[{"identity":"user2","op":"add"}]}',
+  );
   await hasToast('Group "group1" was created.', "positive");
 });
 
@@ -242,11 +273,15 @@ test("should handle errors when adding users", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add users/ }));
-  await userEvent.type(
-    screen.getByRole("textbox", {
+  // Wait for the options to load.
+  await screen.findByRole("option", {
+    name: "user2@example.com",
+  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
       name: IdentitiesPanelFormLabel.USER,
     }),
-    "joe",
+    "user2@example.com",
   );
   await userEvent.click(
     screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
@@ -278,11 +313,15 @@ test("should add roles", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add roles/ }));
-  await userEvent.type(
-    screen.getByRole("textbox", {
+  // Wait for the options to load.
+  await screen.findByRole("option", {
+    name: "role3",
+  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
       name: RolesPanelFormLabel.ROLE,
     }),
-    "admin",
+    "role3",
   );
   await userEvent.click(
     screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),
@@ -292,7 +331,7 @@ test("should add roles", async () => {
   );
   await userEvent.click(screen.getByRole("button", { name: "Create group" }));
   await waitFor(() => expect(patchDone).toBeTruthy());
-  expect(patchResponseBody).toBe('{"patches":[{"role":"admin","op":"add"}]}');
+  expect(patchResponseBody).toBe('{"patches":[{"role":"role345","op":"add"}]}');
   await hasToast('Group "group1" was created.', "positive");
 });
 
@@ -309,11 +348,15 @@ test("should handle errors when adding roles", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add roles/ }));
-  await userEvent.type(
-    screen.getByRole("textbox", {
+  // Wait for the options to load.
+  await screen.findByRole("option", {
+    name: "role3",
+  });
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
       name: RolesPanelFormLabel.ROLE,
     }),
-    "admin",
+    "role3",
   );
   await userEvent.click(
     screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
@@ -27,6 +27,7 @@ import AddGroupPanel from "./AddGroupPanel";
 import { Label } from "./types";
 
 const mockGroupsData = getPostGroupsResponseMock({
+  id: "group123",
   name: "group1",
 });
 const mockApiServer = setupServer(
@@ -76,6 +77,24 @@ test("should handle errors when adding groups", async () => {
   );
 });
 
+// eslint-disable-next-line vitest/expect-expect
+test("should handle no id in the group response", async () => {
+  mockApiServer.use(
+    getPostGroupsMockHandler(
+      getPostGroupsResponseMock({
+        id: null,
+        name: "group1",
+      }),
+    ),
+  );
+  renderComponent(<AddGroupPanel close={vi.fn()} setPanelWidth={vi.fn()} />);
+  await userEvent.type(
+    screen.getByRole("textbox", { name: GroupPanelLabel.NAME }),
+    "group1{Enter}",
+  );
+  await hasToast(Label.GROUP_ID_ERROR, NotificationSeverity.NEGATIVE);
+});
+
 test("should add entitlements", async () => {
   let patchResponseBody: string | null = null;
   let patchDone = false;
@@ -84,7 +103,7 @@ test("should add entitlements", async () => {
     const requestClone = request.clone();
     if (
       requestClone.method === "PATCH" &&
-      requestClone.url.endsWith("/groups/group1/entitlements")
+      requestClone.url.endsWith("/groups/group123/entitlements")
     ) {
       patchResponseBody = await requestClone.text();
       patchDone = true;
@@ -180,7 +199,7 @@ test("should add users", async () => {
     const requestClone = request.clone();
     if (
       requestClone.method === "PATCH" &&
-      requestClone.url.endsWith("/groups/group1/identities")
+      requestClone.url.endsWith("/groups/group123/identities")
     ) {
       patchResponseBody = await requestClone.text();
       patchDone = true;
@@ -247,7 +266,7 @@ test("should add roles", async () => {
     const requestClone = request.clone();
     if (
       requestClone.method === "PATCH" &&
-      requestClone.url.endsWith("/groups/group1/roles")
+      requestClone.url.endsWith("/groups/group123/roles")
     ) {
       patchResponseBody = await requestClone.text();
       patchDone = true;

--- a/src/components/pages/Groups/AddGroupPanel/types.ts
+++ b/src/components/pages/Groups/AddGroupPanel/types.ts
@@ -9,4 +9,5 @@ export enum Label {
   ENTITLEMENTS_ERROR = "Some entitlements couldn't be added",
   IDENTITIES_ERROR = "Some users couldn't be added",
   ROLES_ERROR = "Some roles couldn't be added",
+  GROUP_ID_ERROR = "The group was not created correctly",
 }

--- a/src/components/pages/Groups/DeleteGroupsPanel/types.ts
+++ b/src/components/pages/Groups/DeleteGroupsPanel/types.ts
@@ -3,7 +3,7 @@ import type { Group } from "api/api.schemas";
 import type { GroupPanelProps } from "../GroupPanel";
 
 export type Props = {
-  groups: Group["name"][];
+  groups: NonNullable<Group["id"]>[];
   close: GroupPanelProps["close"];
 };
 

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
 import { vi } from "vitest";
 
-import type { Group } from "api/api.schemas";
 import {
   getPatchGroupsItemEntitlementsMockHandler,
   getPatchGroupsItemEntitlementsMockHandler400,
@@ -19,15 +18,13 @@ import {
   getGetGroupsItemRolesMockHandler,
   getGetGroupsItemRolesResponseMock,
   getPatchGroupsItemRolesMockHandler400,
-  getGetGroupsItemMockHandler400,
-  getGetGroupsItemResponseMock400,
   getGetGroupsItemMockHandler,
   getGetGroupsItemResponseMock,
 } from "api/groups/groups.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
 import { Label as IdentitiesPanelFormLabel } from "components/pages/Groups/IdentitiesPanelForm/types";
 import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm/types";
-import { hasNotification, hasToast, renderComponent } from "test/utils";
+import { hasToast, renderComponent } from "test/utils";
 
 import EditGroupPanel from "./EditGroupPanel";
 import { Label } from "./types";
@@ -59,7 +56,10 @@ const mockApiServer = setupServer(
   getPatchGroupsItemRolesMockHandler(),
   getGetGroupsItemRolesMockHandler(
     getGetGroupsItemRolesResponseMock({
-      data: [{ name: "role1" }, { name: "role2" }],
+      data: [
+        { id: "role123", name: "role1" },
+        { id: "role234", name: "role2" },
+      ],
     }),
   ),
   getGetGroupsItemMockHandler(
@@ -79,32 +79,6 @@ afterAll(() => {
   mockApiServer.close();
 });
 
-// eslint-disable-next-line vitest/expect-expect
-test("should handle errors when getting the group", async () => {
-  mockApiServer.use(
-    getGetGroupsItemMockHandler400(
-      getGetGroupsItemResponseMock400({ message: "group not found" }),
-    ),
-  );
-  renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
-  );
-  await hasNotification(
-    "Unable to get group: group not found",
-    NotificationSeverity.NEGATIVE,
-  );
-});
-
-// eslint-disable-next-line vitest/expect-expect
-test("should handle the group not in the response", async () => {
-  // Mock the group not in the response, which is not a valid type.
-  mockApiServer.use(getGetGroupsItemMockHandler(null as unknown as Group));
-  renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
-  );
-  await hasNotification("Unable to get group", NotificationSeverity.NEGATIVE);
-});
-
 test("should add and remove entitlements", async () => {
   let patchResponseBody: string | null = null;
   let patchDone = false;
@@ -120,7 +94,12 @@ test("should add and remove entitlements", async () => {
     }
   });
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
@@ -176,7 +155,12 @@ test("should handle errors when updating entitlements", async () => {
     getGetGroupsItemEntitlementsMockHandler400(),
   );
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
@@ -231,7 +215,12 @@ test("should add and remove users", async () => {
     }
   });
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the users have loaded.
   await screen.findByText("2 users");
@@ -265,7 +254,12 @@ test("should add and remove users", async () => {
 test("should handle errors when updating users", async () => {
   mockApiServer.use(getPatchGroupsItemIdentitiesMockHandler400());
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the users have loaded.
   await screen.findByText("2 users");
@@ -301,7 +295,12 @@ test("should add and remove roles", async () => {
     }
   });
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the roles have loaded.
   await screen.findByText("2 roles");
@@ -335,7 +334,12 @@ test("should add and remove roles", async () => {
 test("should handle errors when updating roles", async () => {
   mockApiServer.use(getPatchGroupsItemRolesMockHandler400());
   renderComponent(
-    <EditGroupPanel groupId="admin1" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditGroupPanel
+      group={{ id: "admin1", name: "admin" }}
+      groupId="admin1"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the roles have loaded.
   await screen.findByText("2 roles");

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
@@ -14,7 +14,6 @@ import {
   GroupRolesPatchItemOp,
 } from "api/api.schemas";
 import {
-  useGetGroupsItem,
   useGetGroupsItemEntitlements,
   useGetGroupsItemIdentities,
   useGetGroupsItemRoles,
@@ -24,6 +23,7 @@ import {
 } from "api/groups/groups";
 import ToastCard from "components/ToastCard";
 import { API_CONCURRENCY } from "consts";
+import { getIds } from "utils/getIds";
 
 import GroupPanel from "../GroupPanel";
 
@@ -34,15 +34,7 @@ const generateError = (
   getGroupsItemEntitlementsError: AxiosError<Response> | null,
   getGroupsItemIdentitiesError: AxiosError<Response> | null,
   getGroupsItemRolesError: AxiosError<Response> | null,
-  getGroupsItemError: AxiosError<Response> | null,
-  noGroup: boolean,
 ) => {
-  if (getGroupsItemError) {
-    return `Unable to get group: ${getGroupsItemError.response?.data.message}`;
-  }
-  if (noGroup) {
-    return "Unable to get group";
-  }
   if (getGroupsItemEntitlementsError) {
     return `Unable to get entitlements: ${getGroupsItemEntitlementsError.response?.data.message}`;
   }
@@ -55,13 +47,7 @@ const generateError = (
   return null;
 };
 
-const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
-  const {
-    error: getGroupsItemError,
-    data: groupDetails,
-    isFetching: isFetchingGroup,
-    isFetched: isFetchedGroup,
-  } = useGetGroupsItem(groupId);
+const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
   const {
     error: getGroupsItemEntitlementsError,
     data: existingEntitlements,
@@ -89,7 +75,6 @@ const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
     mutateAsync: patchGroupsItemRoles,
     isPending: isPatchGroupsItemRolesPending,
   } = usePatchGroupsItemRoles();
-  const group = groupDetails?.data;
   return (
     <GroupPanel
       close={close}
@@ -97,8 +82,6 @@ const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
         getGroupsItemEntitlementsError,
         getGroupsItemIdentitiesError,
         getGroupsItemRolesError,
-        getGroupsItemError,
-        isFetchedGroup && !group,
       )}
       existingEntitlements={existingEntitlements?.data.data}
       existingIdentities={existingIdentities?.data.data}
@@ -107,7 +90,6 @@ const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
       isFetchingExistingEntitlements={isFetchingExistingEntitlements}
       isFetchingExistingIdentities={isFetchingExistingIdentities}
       isFetchingExistingRoles={isFetchingExistingRoles}
-      isFetchingGroup={isFetchingGroup}
       isSaving={
         isPatchGroupsItemEntitlementsPending ||
         isPatchGroupsItemIdentitiesPending ||
@@ -162,16 +144,16 @@ const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
           let patches: GroupIdentitiesPatchItem[] = [];
           if (addIdentities.length) {
             patches = patches.concat(
-              addIdentities.map(({ email }) => ({
-                identity: email,
+              getIds(addIdentities).map((id) => ({
+                identity: id,
                 op: GroupIdentitiesPatchItemOp.add,
               })),
             );
           }
           if (removeIdentities?.length) {
             patches = patches.concat(
-              removeIdentities.map(({ email }) => ({
-                identity: email,
+              getIds(removeIdentities).map((id) => ({
+                identity: id,
                 op: GroupIdentitiesPatchItemOp.remove,
               })),
             );
@@ -195,16 +177,16 @@ const EditGroupPanel = ({ close, groupId, setPanelWidth }: Props) => {
             let patches: GroupRolesPatchItem[] = [];
             if (addRoles.length) {
               patches = patches.concat(
-                addRoles.map(({ name }) => ({
-                  role: name,
+                getIds(addRoles).map((id) => ({
+                  role: id,
                   op: GroupRolesPatchItemOp.add,
                 })),
               );
             }
             if (removeRoles?.length) {
               patches = patches.concat(
-                removeRoles.map(({ name }) => ({
-                  role: name,
+                getIds(removeRoles).map((id) => ({
+                  role: id,
                   op: GroupRolesPatchItemOp.remove,
                 })),
               );

--- a/src/components/pages/Groups/EditGroupPanel/types.ts
+++ b/src/components/pages/Groups/EditGroupPanel/types.ts
@@ -1,8 +1,11 @@
+import type { Group } from "api/api.schemas";
+
 import type { GroupPanelProps } from "../GroupPanel";
 
 export type Props = {
   close: GroupPanelProps["close"];
-  groupId: string;
+  group: Group;
+  groupId: NonNullable<Group["id"]>;
   setPanelWidth: GroupPanelProps["setPanelWidth"];
 };
 

--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -22,7 +22,11 @@ import Groups from "./Groups";
 import { Label as GroupsLabel, Label } from "./types";
 
 const mockGroupsData = getGetGroupsResponseMock({
-  data: [{ name: "global" }, { name: "administrator" }, { name: "viewer" }],
+  data: [
+    { id: "group1", name: "global" },
+    { id: "group2", name: "administrator" },
+    { id: "group3", name: "viewer" },
+  ],
 });
 const mockApiServer = setupServer(
   getGetGroupsItemMockHandler(),

--- a/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
+++ b/src/components/pages/Roles/AddRolePanel/AddRolePanel.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import reactHotToast from "react-hot-toast";
 
+import type { Role } from "api/api.schemas";
 import { RoleEntitlementsPatchItemAllOfOp } from "api/api.schemas";
 import { usePatchRolesItemEntitlements, usePostRoles } from "api/roles/roles";
 import ToastCard from "components/ToastCard";
@@ -33,7 +34,7 @@ const AddRolePanel = ({ close, setPanelWidth }: Props) => {
       }
       isSaving={isPostRolesPending || isPatchRolesItemEntitlementsPending}
       onSubmit={async ({ name }, addEntitlements) => {
-        let id: string | null = null;
+        let id: Role["id"] | null = null;
         try {
           const { data: role } = await postRoles({ data: { name } });
           id = role?.id ?? null;

--- a/src/components/pages/Roles/DeleteRolesPanel/types.ts
+++ b/src/components/pages/Roles/DeleteRolesPanel/types.ts
@@ -3,7 +3,7 @@ import type { Role } from "api/api.schemas";
 import type { Props as RolePanelProps } from "../RolePanel";
 
 export type Props = {
-  roles: Role["name"][];
+  roles: NonNullable<Role["id"]>[];
   close: RolePanelProps["close"];
 };
 

--- a/src/components/pages/Roles/EditRolePanel/EditRolePanel.test.tsx
+++ b/src/components/pages/Roles/EditRolePanel/EditRolePanel.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
 import { vi } from "vitest";
 
-import type { Role } from "api/api.schemas";
 import {
   getPatchRolesItemEntitlementsMockHandler,
   getPatchRolesItemEntitlementsMockHandler400,
@@ -13,11 +12,9 @@ import {
   getGetRolesItemEntitlementsMockHandler400,
   getGetRolesItemMockHandler,
   getGetRolesItemResponseMock,
-  getGetRolesItemMockHandler400,
-  getGetRolesItemResponseMock400,
 } from "api/roles/roles.msw";
 import { Label as EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm/types";
-import { hasToast, renderComponent, hasNotification } from "test/utils";
+import { hasToast, renderComponent } from "test/utils";
 
 import EditRolePanel from "./EditRolePanel";
 
@@ -59,36 +56,6 @@ afterAll(() => {
   mockApiServer.close();
 });
 
-// eslint-disable-next-line vitest/expect-expect
-test("should handle errors when getting the role", async () => {
-  mockApiServer.use(
-    getGetRolesItemMockHandler400(
-      getGetRolesItemResponseMock400({ message: "role not found" }),
-    ),
-  );
-  renderComponent(
-    <EditRolePanel roleId="admin123" close={vi.fn()} setPanelWidth={vi.fn()} />,
-  );
-  await hasNotification(
-    "Unable to get role: role not found",
-    NotificationSeverity.NEGATIVE,
-  );
-});
-
-// eslint-disable-next-line vitest/expect-expect
-test("should handle the role not in the response", async () => {
-  mockApiServer.use(
-    getGetRolesItemMockHandler(
-      // Mimic something wrong with the response, that is not allowed by the type.
-      null as unknown as Role,
-    ),
-  );
-  renderComponent(
-    <EditRolePanel roleId="admin123" close={vi.fn()} setPanelWidth={vi.fn()} />,
-  );
-  await hasNotification("Unable to get role", NotificationSeverity.NEGATIVE);
-});
-
 test("should add and remove entitlements", async () => {
   let patchResponseBody: string | null = null;
   let patchDone = false;
@@ -104,7 +71,15 @@ test("should add and remove entitlements", async () => {
     }
   });
   renderComponent(
-    <EditRolePanel roleId="admin123" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditRolePanel
+      role={{
+        id: "admin123",
+        name: "admin1",
+      }}
+      roleId="admin123"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");
@@ -171,7 +146,15 @@ test("should handle errors when updating entitlements", async () => {
     getGetRolesItemEntitlementsMockHandler400(),
   );
   renderComponent(
-    <EditRolePanel roleId="admin123" close={vi.fn()} setPanelWidth={vi.fn()} />,
+    <EditRolePanel
+      role={{
+        id: "admin123",
+        name: "admin1",
+      }}
+      roleId="admin123"
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+    />,
   );
   // Wait until the entitlements have loaded.
   await screen.findByText("2 entitlements");

--- a/src/components/pages/Roles/EditRolePanel/EditRolePanel.tsx
+++ b/src/components/pages/Roles/EditRolePanel/EditRolePanel.tsx
@@ -5,7 +5,6 @@ import reactHotToast from "react-hot-toast";
 import type { Response, RoleEntitlementsPatchItem } from "api/api.schemas";
 import { RoleEntitlementsPatchItemAllOfOp } from "api/api.schemas";
 import {
-  useGetRolesItem,
   useGetRolesItemEntitlements,
   usePatchRolesItemEntitlements,
 } from "api/roles/roles";
@@ -18,28 +17,14 @@ import type { Props } from "./types";
 
 const generateError = (
   getRolesItemEntitlementsError: AxiosError<Response> | null,
-  getRolesItemError: AxiosError<Response> | null,
-  noRole: boolean,
 ) => {
-  if (getRolesItemError) {
-    return `Unable to get role: ${getRolesItemError.response?.data.message}`;
-  }
-  if (noRole) {
-    return "Unable to get role";
-  }
   if (getRolesItemEntitlementsError) {
     return `Unable to get entitlements: ${getRolesItemEntitlementsError.response?.data.message}`;
   }
   return null;
 };
 
-const EditRolePanel = ({ close, roleId, setPanelWidth }: Props) => {
-  const {
-    error: getRolesItemError,
-    data: roleDetails,
-    isFetching: isFetchingRole,
-    isFetched: isFetchedRole,
-  } = useGetRolesItem(roleId);
+const EditRolePanel = ({ close, roleId, role, setPanelWidth }: Props) => {
   const {
     error: getRolesItemEntitlementsError,
     data: existingEntitlements,
@@ -49,19 +34,13 @@ const EditRolePanel = ({ close, roleId, setPanelWidth }: Props) => {
     mutateAsync: patchRolesItemEntitlements,
     isPending: isPatchRolesItemEntitlementsPending,
   } = usePatchRolesItemEntitlements();
-  const role = roleDetails?.data;
   return (
     <RolePanel
       close={close}
-      error={generateError(
-        getRolesItemEntitlementsError,
-        getRolesItemError,
-        isFetchedRole && !role,
-      )}
+      error={generateError(getRolesItemEntitlementsError)}
       existingEntitlements={existingEntitlements?.data.data}
       isEditing
       isFetchingExisting={isFetchingExisting}
-      isFetchingRole={isFetchingRole}
       isSaving={isPatchRolesItemEntitlementsPending}
       onSubmit={async (_values, addEntitlements, removeEntitlements) => {
         let hasError = false;

--- a/src/components/pages/Roles/EditRolePanel/types.ts
+++ b/src/components/pages/Roles/EditRolePanel/types.ts
@@ -1,7 +1,10 @@
+import type { Role } from "api/api.schemas";
+
 import type { Props as RolePanelProps } from "../RolePanel";
 
 export type Props = {
   close: RolePanelProps["close"];
-  roleId: string;
+  role: Role;
+  roleId: NonNullable<Role["id"]>;
   setPanelWidth: RolePanelProps["setPanelWidth"];
 };

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -20,7 +20,11 @@ import Roles from "./Roles";
 import { Label, Label as RolesLabel } from "./types";
 
 const mockRolesData = getGetRolesResponseMock({
-  data: [{ name: "global" }, { name: "administrator" }, { name: "viewer" }],
+  data: [
+    { id: "role1", name: "global" },
+    { id: "role2", name: "administrator" },
+    { id: "role3", name: "viewer" },
+  ],
 });
 const mockApiServer = setupServer(
   getGetRolesMockHandler(mockRolesData),

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -17,6 +17,7 @@ import ErrorNotification from "components/ErrorNotification";
 import NoEntityCard from "components/NoEntityCard";
 import { useEntitiesSelect, usePanel } from "hooks";
 import { Endpoint } from "types/api";
+import { getIds } from "utils/getIds";
 
 import AddRolePanel from "./AddRolePanel";
 import DeleteRolesPanel from "./DeleteRolesPanel";
@@ -37,13 +38,14 @@ const COLUMN_DATA = [
 const Roles = () => {
   const { data, isFetching, isError, error, refetch } = useGetRoles();
   const { generatePanel, openPanel, isPanelOpen } = usePanel<{
-    editRoleId?: string | null;
-    deleteRoles?: Role["name"][];
+    editRole?: Role | null;
+    deleteRoles?: NonNullable<Role["id"]>[];
   }>((closePanel, data, setPanelWidth) => {
-    if (data?.editRoleId) {
+    if (data?.editRole && data.editRole.id) {
       return (
         <EditRolePanel
-          roleId={data.editRoleId}
+          role={data.editRole}
+          roleId={data.editRole.id}
           close={closePanel}
           setPanelWidth={setPanelWidth}
         />
@@ -60,10 +62,10 @@ const Roles = () => {
     handleSelectAllEntities: handleSelectAllRoles,
     selectedEntities: selectedRoles,
     areAllEntitiesSelected: areAllRolesSelected,
-  } = useEntitiesSelect(data?.data.data.map(({ name }) => name) ?? []);
+  } = useEntitiesSelect(getIds(data?.data.data));
 
   const tableData = useMemo<Record<string, ReactNode>[]>(() => {
-    const roles = data?.data.data.map(({ name }) => name);
+    const roles = data?.data.data;
     if (!roles) {
       return [];
     }
@@ -72,12 +74,15 @@ const Roles = () => {
         <CheckboxInput
           label=""
           inline
-          checked={areAllRolesSelected || selectedRoles.includes(role)}
-          onChange={() => handleSelectRole(role)}
+          checked={
+            areAllRolesSelected ||
+            (!!role.id && selectedRoles.includes(role.id))
+          }
+          onChange={() => role.id && handleSelectRole(role.id)}
           disabled={isPanelOpen}
         />
       ),
-      roleName: role,
+      roleName: role.name,
       actions: (
         <ContextualMenu
           links={[
@@ -89,7 +94,7 @@ const Roles = () => {
                 </>
               ),
               onClick: () => {
-                openPanel({ editRoleId: role });
+                openPanel({ editRole: role });
               },
             },
             {
@@ -100,7 +105,7 @@ const Roles = () => {
                 </>
               ),
               onClick: () => {
-                openPanel({ deleteRoles: [role] });
+                role.id && openPanel({ deleteRoles: [role.id] });
               },
             },
           ]}

--- a/src/components/pages/Users/Users.tsx
+++ b/src/components/pages/Users/Users.tsx
@@ -18,6 +18,7 @@ import ErrorNotification from "components/ErrorNotification";
 import { usePanel, useEntitiesSelect } from "hooks";
 import { Endpoint } from "types/api";
 import urls from "urls";
+import { getIds } from "utils/getIds";
 
 import AddUserPanel from "./AddUserPanel";
 import DeleteUsersPanel from "./DeleteUsersPanel";
@@ -75,14 +76,7 @@ const Users = () => {
     handleSelectAllEntities: handleSelectAllIdentities,
     selectedEntities: selectedIdentities,
     areAllEntitiesSelected: areAllIdentitiesSelected,
-  } = useEntitiesSelect(
-    data?.data.data.reduce<NonNullable<Identity["id"]>[]>((ids, { id }) => {
-      if (id) {
-        ids.push(id);
-      }
-      return ids;
-    }, []) ?? [],
-  );
+  } = useEntitiesSelect(getIds(data?.data.data));
 
   const tableData = useMemo<Record<string, ReactNode>[]>(() => {
     const users = data?.data.data;

--- a/src/utils/getIds.test.ts
+++ b/src/utils/getIds.test.ts
@@ -1,0 +1,7 @@
+import { getIds } from "./getIds";
+
+test("can handle a URL parameter", () => {
+  expect(
+    getIds([{ id: "entity1" }, { name: "entity2" }, { id: "entity3" }]),
+  ).toStrictEqual(["entity1", "entity3"]);
+});

--- a/src/utils/getIds.ts
+++ b/src/utils/getIds.ts
@@ -1,0 +1,18 @@
+import { logger } from "utils/logger";
+
+type Entity = {
+  id?: unknown;
+};
+
+export const getIds = <E extends Entity>(entities?: E[]) => {
+  return (
+    entities?.reduce<NonNullable<E["id"]>[]>((ids, entity) => {
+      if (entity.id) {
+        ids.push(entity.id);
+      } else {
+        logger.warn("entity doesn't contain an ID:", entity);
+      }
+      return ids;
+    }, []) ?? []
+  );
+};


### PR DESCRIPTION
## Done

- Use entity ids for all operations.
- Temporarily implement selecting identites and roles from the API.

## QA

- Go to a form such as for adding a group.
- Fill in the form and add some related entities and submit.
- The group should get added and opening the edit form should show the related entities.

## Details

https://warthogs.atlassian.net/browse/WD-13045
