### PR TITLE
feat: add user summary

### DIFF
--- a/src/components/ListCard/ListCard.test.tsx
+++ b/src/components/ListCard/ListCard.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from "@testing-library/react";
+
+import { renderComponent } from "test/utils";
+
+import ListCard from "./ListCard";
+
+test("displays the title", async () => {
+  const title = "card title";
+  renderComponent(<ListCard title={title} lists={[]} />);
+  expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+});
+
+test("displays multiple lists", async () => {
+  renderComponent(
+    <ListCard
+      title=""
+      lists={[
+        { title: "list1 title", items: [] },
+        { title: "list2 title", items: [] },
+      ]}
+    />,
+  );
+  expect(
+    screen.getByRole("heading", { name: "list1 title" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: "list2 title" }),
+  ).toBeInTheDocument();
+});

--- a/src/components/ListCard/ListCard.tsx
+++ b/src/components/ListCard/ListCard.tsx
@@ -1,0 +1,25 @@
+import { Card, Col, Row } from "@canonical/react-components";
+
+import ListCardList from "./ListCardList";
+import type { Props } from "./types";
+
+import "./_list-card.scss";
+
+const ListCard = ({ lists, title }: Props) => {
+  return (
+    <Row>
+      <Col size={4}>
+        <Card className="list-card">
+          <h4 className="list-card-title p-heading--5 p-text--small u-text--muted">
+            {title}
+          </h4>
+          {lists.map((list, i) => (
+            <ListCardList key={i} {...list} />
+          ))}
+        </Card>
+      </Col>
+    </Row>
+  );
+};
+
+export default ListCard;

--- a/src/components/ListCard/ListCardList/ListCardList.test.tsx
+++ b/src/components/ListCard/ListCardList/ListCardList.test.tsx
@@ -1,0 +1,20 @@
+import { screen, within } from "@testing-library/react";
+
+import { renderComponent } from "test/utils";
+
+import ListCardList from "./ListCardList";
+
+test("displays the title", async () => {
+  const title = "list title";
+  renderComponent(<ListCardList title={title} items={[]} />);
+  expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+});
+
+test("displays items", async () => {
+  renderComponent(
+    <ListCardList title="" items={[{ label: "username", value: "joe" }]} />,
+  );
+  const listitem = screen.getByRole("listitem");
+  expect(within(listitem).getByText("username")).toBeInTheDocument();
+  expect(within(listitem).getByText("joe")).toBeInTheDocument();
+});

--- a/src/components/ListCard/ListCardList/ListCardList.tsx
+++ b/src/components/ListCard/ListCardList/ListCardList.tsx
@@ -1,0 +1,27 @@
+import { List } from "@canonical/react-components";
+
+import type { Props } from "./types";
+
+import "./_list-card-list.scss";
+
+const ListCardList = ({ title, items }: Props) => {
+  return (
+    <>
+      <h5 className="list-card-list__title u-no-margin--bottom">{title}</h5>
+      <List
+        divided
+        items={items.map(({ label, value }) => ({
+          className: "list-card-list__row",
+          content: (
+            <>
+              <span className="list-card-list__col u-text--muted">{label}</span>
+              <span className="list-card-list__col">{value || "-"}</span>
+            </>
+          ),
+        }))}
+      />
+    </>
+  );
+};
+
+export default ListCardList;

--- a/src/components/ListCard/ListCardList/_list-card-list.scss
+++ b/src/components/ListCard/ListCardList/_list-card-list.scss
@@ -1,0 +1,17 @@
+@import "vanilla-framework/scss/vanilla";
+
+.p-list--divided .list-card-list {
+  &__title {
+    font-weight: normal;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    padding-bottom: $spv--small;
+  }
+
+  &__col {
+    word-break: break-all;
+  }
+}

--- a/src/components/ListCard/ListCardList/index.ts
+++ b/src/components/ListCard/ListCardList/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ListCardList";
+export type { Props as ListCardListProps } from "./types";

--- a/src/components/ListCard/ListCardList/types.ts
+++ b/src/components/ListCard/ListCardList/types.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export type ListItem = {
+  label: ReactNode;
+  value?: ReactNode;
+};
+
+export type Props = {
+  title: ReactNode;
+  items: ListItem[];
+};

--- a/src/components/ListCard/_list-card.scss
+++ b/src/components/ListCard/_list-card.scss
@@ -1,0 +1,8 @@
+@import "vanilla-framework/scss/vanilla";
+
+.list-card {
+  &-title {
+    margin-bottom: $spv--large * 2;
+    text-transform: uppercase;
+  }
+}

--- a/src/components/ListCard/index.ts
+++ b/src/components/ListCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ListCard";
+export type { Props as ListCardProps } from "./types";

--- a/src/components/ListCard/types.ts
+++ b/src/components/ListCard/types.ts
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+
+import type { ListCardListProps } from "./ListCardList";
+
+export type Props = {
+  lists: ListCardListProps[];
+  title: ReactNode;
+};

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -8,6 +8,7 @@ import { Route, Routes } from "react-router-dom";
 import Groups from "components/pages/Groups";
 import Roles from "components/pages/Roles";
 import Users from "components/pages/Users";
+import SummaryTab from "components/pages/Users/SummaryTab";
 import User from "components/pages/Users/User";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
 import urls from "urls";
@@ -34,6 +35,8 @@ const ReBACAdmin = ({
       queries: {
         refetchOnWindowFocus: false,
         retry: false,
+        // Cache queries for 30 seconds by default.
+        staleTime: 30000,
       },
     },
   });
@@ -73,7 +76,7 @@ const ReBACAdmin = ({
             <Route path={urls.users.user.index(null)} element={<User />}>
               <Route
                 path={urls.users.user.index(null)}
-                element={<>Summary{/* TODO: display user summary */}</>}
+                element={<SummaryTab />}
               />
               <Route
                 path={urls.users.user.groups(null)}

--- a/src/components/pages/Users/SummaryTab/SummaryTab.test.tsx
+++ b/src/components/pages/Users/SummaryTab/SummaryTab.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from "@testing-library/react";
+import { setupServer } from "msw/node";
+
+import {
+  getGetIdentitiesItemMockHandler,
+  getGetIdentitiesItemResponseMock,
+} from "api/identities/identities.msw";
+import { getGetActualCapabilitiesMock } from "mocks/capabilities";
+import { renderComponent } from "test/utils";
+import urls from "urls";
+
+import SummaryTab from "./SummaryTab";
+
+const mockUserData = getGetIdentitiesItemResponseMock({
+  id: "user1",
+  addedBy: "within",
+  email: "pfft",
+  firstName: "first",
+  lastName: "last",
+  source: "noteworthy",
+});
+const mockApiServer = setupServer(
+  getGetIdentitiesItemMockHandler(mockUserData),
+  ...getGetActualCapabilitiesMock(),
+);
+
+const path = urls.users.user.index(null);
+const url = urls.users.user.index({ id: "user1" });
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+test("displays full name", async () => {
+  renderComponent(<SummaryTab />, {
+    path,
+    url,
+  });
+  expect(await screen.findByText("first last")).toBeInTheDocument();
+});

--- a/src/components/pages/Users/SummaryTab/SummaryTab.tsx
+++ b/src/components/pages/Users/SummaryTab/SummaryTab.tsx
@@ -1,0 +1,62 @@
+import { Col, Row } from "@canonical/react-components";
+import { useParams } from "react-router-dom";
+
+import { useGetIdentitiesItem } from "api/identities/identities";
+import ListCard from "components/ListCard";
+
+const SummaryTab = () => {
+  const { id: userId } = useParams<{ id: string }>();
+  // Loading states and errors for the user are handled in the parent component.
+  const { data } = useGetIdentitiesItem(userId ?? "");
+  const user = data?.data;
+
+  return (
+    <Row>
+      <Col size={4}>
+        <ListCard
+          title="details"
+          lists={[
+            {
+              title: "General information",
+              items: [
+                {
+                  label: "Full name",
+                  value: [user?.firstName, user?.lastName]
+                    .filter(Boolean)
+                    .join(" "),
+                },
+                {
+                  label: "Email",
+                  value: user?.email,
+                },
+              ],
+            },
+            {
+              title: "Account details",
+              items: [
+                {
+                  label: "Last login",
+                  value: user?.lastLogin,
+                },
+                {
+                  label: "Joined",
+                  value: user?.joined,
+                },
+                {
+                  label: "Added by",
+                  value: user?.addedBy,
+                },
+                {
+                  label: "User source",
+                  value: user?.source,
+                },
+              ],
+            },
+          ]}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default SummaryTab;

--- a/src/components/pages/Users/SummaryTab/index.ts
+++ b/src/components/pages/Users/SummaryTab/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SummaryTab";
+export { Label as SummaryTabLabel } from "./types";

--- a/src/components/pages/Users/SummaryTab/types.ts
+++ b/src/components/pages/Users/SummaryTab/types.ts
@@ -1,0 +1,3 @@
+export enum Label {
+  LOADING = "Loading user.",
+}


### PR DESCRIPTION
## Done

- Add user summary tab (without counts as that's not currently possible).

## QA

- Go to the user list and click on a user and you should see the user's summary tab with some details.

## Details

https://warthogs.atlassian.net/browse/WD-12399