### PR TITLE
WD-13336 - feat: add search to users, roles and groups

### DIFF
--- a/src/components/Content/Content.test.tsx
+++ b/src/components/Content/Content.test.tsx
@@ -1,5 +1,7 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
+import { vi } from "vitest";
 
 import { Label as CheckCapabilityLabel } from "components/CheckCapability";
 import { getGetActualCapabilitiesMock } from "mocks/capabilities";
@@ -61,4 +63,30 @@ test("should not display content if capability is disabled", async () => {
     await screen.findByText(CheckCapabilityLabel.DISABLED_FEATURE),
   ).toBeInTheDocument();
   expect(screen.queryByText(content)).not.toBeInTheDocument();
+});
+
+test("displays a search box", async () => {
+  mockApiServer.use(...getGetActualCapabilitiesMock([]));
+  renderComponent(
+    <Content
+      title="Mock content title"
+      endpoint={Endpoint.META}
+      onSearch={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole("searchbox")).toBeInTheDocument();
+});
+
+test("calls the search callback", async () => {
+  mockApiServer.use(...getGetActualCapabilitiesMock([]));
+  const onSearch = vi.fn();
+  renderComponent(
+    <Content
+      title="Mock content title"
+      endpoint={Endpoint.META}
+      onSearch={onSearch}
+    />,
+  );
+  await userEvent.type(screen.getByRole("searchbox"), " group1 {enter}");
+  expect(onSearch).toHaveBeenCalledWith("group1");
 });

--- a/src/components/Content/Content.tsx
+++ b/src/components/Content/Content.tsx
@@ -1,6 +1,6 @@
-import { Panel } from "@canonical/react-components";
-import type { PropsWithChildren, ReactNode } from "react";
-import { type JSX } from "react";
+import { Panel, SearchBox } from "@canonical/react-components";
+import type { PropsWithChildren, ReactNode, JSX } from "react";
+import { useState } from "react";
 
 import CheckCapability from "components/CheckCapability";
 import { CapabilityAction } from "hooks/capabilities";
@@ -11,23 +11,47 @@ import "./_content.scss";
 type Props = {
   controls?: ReactNode;
   endpoint: Endpoint;
+  onSearch?: (searchValue: string) => void;
   title: ReactNode;
 } & PropsWithChildren;
 
 const Content = ({
   children,
   controls,
-  title,
   endpoint,
+  onSearch,
+  title,
   ...props
-}: Props): JSX.Element => (
-  <Panel controls={controls} title={title}>
-    <div className="l-content" {...props}>
-      <CheckCapability endpoint={endpoint} action={CapabilityAction.READ}>
-        {children}
-      </CheckCapability>
-    </div>
-  </Panel>
-);
+}: Props): JSX.Element => {
+  const [searchValue, setSearchValue] = useState("");
+  return (
+    <Panel
+      controls={
+        <>
+          <div className="l-content__controls-search">
+            {onSearch ? (
+              <SearchBox
+                externallyControlled
+                onChange={setSearchValue}
+                onClear={() => onSearch("")}
+                onSearch={() => onSearch(searchValue.trim())}
+                value={searchValue}
+              />
+            ) : null}
+          </div>
+          <div>{controls}</div>
+        </>
+      }
+      controlsClassName="l-content__controls"
+      title={title}
+    >
+      <div className="l-content" {...props}>
+        <CheckCapability endpoint={endpoint} action={CapabilityAction.READ}>
+          {children}
+        </CheckCapability>
+      </div>
+    </Panel>
+  );
+};
 
 export default Content;

--- a/src/components/Content/_content.scss
+++ b/src/components/Content/_content.scss
@@ -2,4 +2,16 @@
 
 .l-content {
   padding: 0 $sph--x-large;
+
+  &__controls {
+    display: flex;
+    flex: 1;
+    gap: $spv--large;
+    margin-left: 0;
+    padding-left: $spv--large;
+
+    &-search {
+      flex: 1;
+    }
+  }
 }

--- a/src/components/pages/Groups/Groups.test.tsx
+++ b/src/components/pages/Groups/Groups.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, delay } from "msw";
 import { setupServer } from "msw/node";
@@ -68,6 +68,23 @@ test("should display correct group data after fetching groups", async () => {
     "administrator",
   );
   expect(within(rows[3]).getAllByRole("cell")[1]).toHaveTextContent("viewer");
+});
+
+test("search groups", async () => {
+  let getDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "GET" &&
+      requestClone.url.endsWith("/groups?filter=group1")
+    ) {
+      getDone = true;
+    }
+  });
+  renderComponent(<Groups />);
+  await userEvent.type(screen.getByRole("searchbox"), "group1{enter}");
+  await waitFor(() => expect(getDone).toBeTruthy());
 });
 
 test("should display no groups data when no groups are available", async () => {

--- a/src/components/pages/Groups/Groups.tsx
+++ b/src/components/pages/Groups/Groups.tsx
@@ -7,8 +7,8 @@ import {
   ButtonAppearance,
   CheckboxInput,
 } from "@canonical/react-components";
-import type { ReactNode } from "react";
-import { useMemo, type JSX } from "react";
+import type { ReactNode, JSX } from "react";
+import { useMemo, useState } from "react";
 
 import type { Group } from "api/api.schemas";
 import { useGetGroups } from "api/groups/groups";
@@ -35,7 +35,10 @@ const COLUMN_DATA = [
 ];
 
 const Groups = () => {
-  const { data, isFetching, isError, error, refetch } = useGetGroups();
+  const [filter, setFilter] = useState("");
+  const { data, isFetching, isError, error, refetch } = useGetGroups({
+    filter: filter || undefined,
+  });
   const { generatePanel, openPanel, isPanelOpen } = usePanel<{
     editGroupId?: string | null;
     deleteGroups?: Group["name"][];
@@ -220,6 +223,7 @@ const Groups = () => {
           {generateCreateGroupButton()}
         </>
       }
+      onSearch={setFilter}
       title="Groups"
     >
       {generateContent()}

--- a/src/components/pages/Roles/Roles.test.tsx
+++ b/src/components/pages/Roles/Roles.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, delay } from "msw";
 import { setupServer } from "msw/node";
@@ -64,6 +64,23 @@ test("should display correct role data after fetching roles", async () => {
     "administrator",
   );
   expect(within(rows[3]).getAllByRole("cell")[1]).toHaveTextContent("viewer");
+});
+
+test("search roles", async () => {
+  let getDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "GET" &&
+      requestClone.url.endsWith("/roles?filter=role1")
+    ) {
+      getDone = true;
+    }
+  });
+  renderComponent(<Roles />);
+  await userEvent.type(screen.getByRole("searchbox"), "role1{enter}");
+  await waitFor(() => expect(getDone).toBeTruthy());
 });
 
 test("should display no roles data when no roles are available", async () => {

--- a/src/components/pages/Roles/Roles.tsx
+++ b/src/components/pages/Roles/Roles.tsx
@@ -8,7 +8,7 @@ import {
   CheckboxInput,
 } from "@canonical/react-components";
 import type { JSX, ReactNode } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import type { Role } from "api/api.schemas";
 import { useGetRoles } from "api/roles/roles";
@@ -35,7 +35,10 @@ const COLUMN_DATA = [
 ];
 
 const Roles = () => {
-  const { data, isFetching, isError, error, refetch } = useGetRoles();
+  const [filter, setFilter] = useState("");
+  const { data, isFetching, isError, error, refetch } = useGetRoles({
+    filter: filter || undefined,
+  });
   const { generatePanel, openPanel, isPanelOpen } = usePanel<{
     editRoleId?: string | null;
     deleteRoles?: Role["name"][];
@@ -218,6 +221,7 @@ const Roles = () => {
         </>
       }
       endpoint={Endpoint.ROLES}
+      onSearch={setFilter}
       title="Roles"
     >
       {generateContent()}

--- a/src/components/pages/Users/Users.test.tsx
+++ b/src/components/pages/Users/Users.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupServer } from "msw/node";
 
@@ -67,6 +67,23 @@ test("should display correct user data after fetching users", async () => {
   expect(firstUserCells[3]).toHaveTextContent("within");
   expect(firstUserCells[4]).toHaveTextContent("pfft");
   expect(firstUserCells[5]).toHaveTextContent("noteworthy");
+});
+
+test("search users", async () => {
+  let getDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "GET" &&
+      requestClone.url.endsWith("/identities?filter=joe")
+    ) {
+      getDone = true;
+    }
+  });
+  renderComponent(<Users />);
+  await userEvent.type(screen.getByRole("searchbox"), "joe{enter}");
+  await waitFor(() => expect(getDone).toBeTruthy());
 });
 
 test("should display no users data when no users are available", async () => {

--- a/src/components/pages/Users/Users.tsx
+++ b/src/components/pages/Users/Users.tsx
@@ -8,7 +8,7 @@ import {
   ButtonAppearance,
 } from "@canonical/react-components";
 import type { ReactNode } from "react";
-import { useMemo, type JSX } from "react";
+import { useMemo, useState, type JSX } from "react";
 import { Link } from "react-router-dom";
 
 import type { Identity } from "api/api.schemas";
@@ -51,7 +51,10 @@ const COLUMN_DATA = [
 ];
 
 const Users = () => {
-  const { data, isFetching, isError, error, refetch } = useGetIdentities();
+  const [filter, setFilter] = useState("");
+  const { data, isFetching, isError, error, refetch } = useGetIdentities({
+    filter: filter || undefined,
+  });
   const { generatePanel, openPanel, isPanelOpen } = usePanel<{
     editIdentityId?: string | null;
     deleteIdentities?: NonNullable<Identity["id"]>[];
@@ -179,7 +182,7 @@ const Users = () => {
   ];
 
   const generateCreateUserButton = () => (
-    <Button appearance={ButtonAppearance.POSITIVE} onClick={openPanel}>
+    <Button appearance={ButtonAppearance.DEFAULT} onClick={openPanel}>
       {Label.ADD}
     </Button>
   );
@@ -249,6 +252,7 @@ const Users = () => {
           {generateCreateUserButton()}
         </>
       }
+      onSearch={setFilter}
       title="Users"
       endpoint={Endpoint.IDENTITIES}
     >


### PR DESCRIPTION
## Done

Add search to the users, roles and groups pages.

## QA

- Open the network dev tools.
- Go to the users, groups and roles pages.
- Enter something in the search field and submit.
- Check that the network request was made with ?filter=[your search string] (the example app does not have filtering implemented so this won't actually return filtered results).

## Details

https://warthogs.atlassian.net/browse/WD-13336
https://warthogs.atlassian.net/browse/WD-13337
https://warthogs.atlassian.net/browse/WD-13338
