### PR TITLE
ci: update TICSAUTHTOKEN in workflow

### DIFF
--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          export TICSAUTHTOKEN=${{ secrets.TICS_AUTH_TOKEN }}
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
           curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
           . ./install_tics.sh
           TICSQServer -project rebac-admin -tmpdir /tmp/tics -branchdir .


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- [Add additional steps]

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
