### PR TITLE
WD-12402 - feat: add user entitlements tab

### DIFF
--- a/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
+++ b/src/components/EntitlementsPanelForm/EntitlementsPanelForm.tsx
@@ -43,10 +43,11 @@ const entitlementMatches = (entitlement: EntityEntitlement, search: string) =>
 
 const EntitlementsPanelForm = ({
   existingEntitlements,
-  addEntitlements,
+  addEntitlements = [],
   setAddEntitlements,
-  removeEntitlements,
+  removeEntitlements = [],
   setRemoveEntitlements,
+  submitProps,
 }: Props) => {
   const {
     data: getEntitlementsData,
@@ -89,7 +90,10 @@ const EntitlementsPanelForm = ({
                 and entitlement below and add it to the list of entitlements for
                 this role.{" "}
               </p>
-              <Fields entitlements={getEntitlementsData?.data.data ?? []} />
+              <Fields
+                entitlements={getEntitlementsData?.data.data ?? []}
+                submitProps={submitProps}
+              />
             </fieldset>
           </Form>
         </Formik>

--- a/src/components/EntitlementsPanelForm/Fields/Fields.tsx
+++ b/src/components/EntitlementsPanelForm/Fields/Fields.tsx
@@ -6,6 +6,7 @@ import type { OptionHTMLAttributes } from "react";
 import type { EntitlementSchema, EntityEntitlement } from "api/api.schemas";
 import { useGetResources } from "api/resources/resources";
 import CleanFormikField from "components/CleanFormikField";
+import type { FormikSubmitButtonProps } from "components/FormikSubmitButton";
 import FormikSubmitButton from "components/FormikSubmitButton";
 import { Endpoint } from "types/api";
 
@@ -15,9 +16,10 @@ import { Label } from "./types";
 
 type Props = {
   entitlements: EntitlementSchema[];
+  submitProps?: Partial<FormikSubmitButtonProps>;
 };
 
-const Fields = ({ entitlements }: Props) => {
+const Fields = ({ entitlements, submitProps }: Props) => {
   const queryClient = useQueryClient();
   const { values, setFieldValue, setFieldTouched } =
     useFormikContext<EntityEntitlement>();
@@ -115,7 +117,7 @@ const Fields = ({ entitlements }: Props) => {
         )}
       />
       <div className="panel-table-form__submit">
-        <FormikSubmitButton>
+        <FormikSubmitButton {...submitProps}>
           {EntitlementsPanelFormLabel.SUBMIT}
         </FormikSubmitButton>
       </div>

--- a/src/components/EntitlementsPanelForm/types.ts
+++ b/src/components/EntitlementsPanelForm/types.ts
@@ -1,11 +1,13 @@
 import type { EntityEntitlement } from "api/api.schemas";
+import type { FormikSubmitButtonProps } from "components/FormikSubmitButton";
 
 export type Props = {
-  addEntitlements: EntityEntitlement[];
+  addEntitlements?: EntityEntitlement[];
   existingEntitlements?: EntityEntitlement[];
-  removeEntitlements: EntityEntitlement[];
+  removeEntitlements?: EntityEntitlement[];
   setAddEntitlements: (addEntitlements: EntityEntitlement[]) => void;
   setRemoveEntitlements: (removeEntitlements: EntityEntitlement[]) => void;
+  submitProps?: Partial<FormikSubmitButtonProps>;
 };
 
 export enum Label {

--- a/src/components/FormikSubmitButton/index.ts
+++ b/src/components/FormikSubmitButton/index.ts
@@ -1,2 +1,3 @@
 export { default } from "./FormikSubmitButton";
+export type { Props as FormikSubmitButtonProps } from "./types";
 export * from "./types";

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -12,6 +12,7 @@ import { Route, Routes } from "react-router-dom";
 import Groups from "components/pages/Groups";
 import Roles from "components/pages/Roles";
 import Users from "components/pages/Users";
+import EntitlementsTab from "components/pages/Users/EntitlementsTab";
 import SummaryTab from "components/pages/Users/SummaryTab";
 import User from "components/pages/Users/User";
 import { ReBACAdminContext } from "context/ReBACAdminContext";
@@ -102,9 +103,7 @@ const ReBACAdmin = ({
               />
               <Route
                 path={urls.users.user.entitlements(null)}
-                element={
-                  <>Entitlements{/* TODO: display user entitlements */}</>
-                }
+                element={<EntitlementsTab />}
               />
               <Route
                 path={urls.users.user.accountManagement(null)}

--- a/src/components/pages/Users/EntitlementsTab/EntitlementsTab.test.tsx
+++ b/src/components/pages/Users/EntitlementsTab/EntitlementsTab.test.tsx
@@ -1,0 +1,227 @@
+import { NotificationSeverity } from "@canonical/react-components";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, delay } from "msw";
+import { setupServer } from "msw/node";
+
+import {
+  getGetEntitlementsMockHandler,
+  getGetEntitlementsResponseMock,
+} from "api/entitlements/entitlements.msw";
+import {
+  getPatchIdentitiesItemEntitlementsMockHandler,
+  getGetIdentitiesItemEntitlementsMockHandler,
+  getGetIdentitiesItemEntitlementsResponseMock,
+  getPatchIdentitiesItemEntitlementsMockHandler400,
+  getGetIdentitiesItemEntitlementsMockHandler400,
+} from "api/identities/identities.msw";
+import {
+  getGetResourcesMockHandler,
+  getGetResourcesResponseMock,
+} from "api/resources/resources.msw";
+import { EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
+import { EntitlementPanelFormFieldsLabel } from "components/EntitlementsPanelForm/Fields";
+import { mockEntityEntitlement } from "mocks/entitlements";
+import { mockEntity, mockResource } from "mocks/resources";
+import { hasNotification, hasSpinner, renderComponent } from "test/utils";
+import { Endpoint } from "types/api";
+import urls from "urls";
+
+import EntitlementsTab from "./EntitlementsTab";
+import { Label } from "./types";
+
+const path = urls.users.user.index(null);
+const url = urls.users.user.index({ id: "user1" });
+
+const mockApiServer = setupServer(
+  getGetEntitlementsMockHandler(
+    getGetEntitlementsResponseMock({
+      data: [
+        mockEntityEntitlement({
+          entitlement: "can_read",
+          entity_id: "editors",
+          entity_type: "client",
+        }),
+      ],
+    }),
+  ),
+  getPatchIdentitiesItemEntitlementsMockHandler(),
+  getGetIdentitiesItemEntitlementsMockHandler(),
+  getGetResourcesMockHandler(
+    getGetResourcesResponseMock({
+      data: [
+        mockResource({
+          entity: mockEntity({
+            id: "mock-entity-id",
+            name: "editors",
+          }),
+        }),
+      ],
+    }),
+  ),
+);
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("display fetch errors", async () => {
+  mockApiServer.use(getGetIdentitiesItemEntitlementsMockHandler400());
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await hasNotification(
+    Label.FETCH_ENTITLEMENTS_ERROR,
+    NotificationSeverity.NEGATIVE,
+  );
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("display loading spinner", async () => {
+  mockApiServer.use(
+    http.get(`*/${Endpoint.IDENTITIES}/*`, async () => {
+      await delay(100);
+    }),
+  );
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await hasSpinner();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("does not display loading spinner when refetching", async () => {
+  mockApiServer.use(
+    http.get(`*/${Endpoint.IDENTITIES}/*`, async () => {
+      await delay(100);
+    }),
+  );
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: EntitlementsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await hasSpinner(undefined, false);
+});
+
+test("should add entitlements", async () => {
+  let patchResponseBody: string | null = null;
+  let patchDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/identities/user1/entitlements")
+    ) {
+      patchResponseBody = await requestClone.text();
+      patchDone = true;
+    }
+  });
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await userEvent.selectOptions(
+    await screen.findByRole("combobox", {
+      name: EntitlementsPanelFormLabel.ENTITY,
+    }),
+    "client",
+  );
+  await screen.findByText(EntitlementPanelFormFieldsLabel.SELECT_RESOURCE);
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
+      name: EntitlementsPanelFormLabel.RESOURCE,
+    }),
+    "editors",
+  );
+  await userEvent.selectOptions(
+    screen.getByRole("combobox", {
+      name: EntitlementsPanelFormLabel.ENTITLEMENT,
+    }),
+    "can_read",
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: EntitlementsPanelFormLabel.SUBMIT }),
+  );
+  await waitFor(() => expect(patchDone).toBe(true));
+  expect(patchResponseBody).toStrictEqual(
+    '{"patches":[{"entitlement":{"entity_type":"client","entitlement":"can_read","entity_id":"mock-entity-id"},"op":"add"}]}',
+  );
+});
+
+test("should remove entitlements", async () => {
+  let patchResponseBody: string | null = null;
+  let patchDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/identities/user1/entitlements")
+    ) {
+      patchResponseBody = await requestClone.text();
+      patchDone = true;
+    }
+  });
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: EntitlementsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await waitFor(() => expect(patchDone).toBe(true));
+  expect(patchResponseBody).toStrictEqual(
+    '{"patches":[{"entitlement":{"entitlement":"can_read","entity_id":"editors","entity_type":"client"},"op":"remove"}]}',
+  );
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should handle errors when updating entitlements", async () => {
+  mockApiServer.use(
+    getGetIdentitiesItemEntitlementsMockHandler(
+      getGetIdentitiesItemEntitlementsResponseMock({
+        data: ["can_edit::moderators:collection", "can_remove::staff:team"],
+      }),
+    ),
+    getPatchIdentitiesItemEntitlementsMockHandler400(),
+    getGetIdentitiesItemEntitlementsMockHandler400(),
+  );
+  renderComponent(<EntitlementsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: EntitlementsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await hasNotification(
+    Label.PATCH_ENTITLEMENTS_ERROR,
+    NotificationSeverity.NEGATIVE,
+  );
+});

--- a/src/components/pages/Users/EntitlementsTab/EntitlementsTab.tsx
+++ b/src/components/pages/Users/EntitlementsTab/EntitlementsTab.tsx
@@ -1,0 +1,116 @@
+import {
+  Spinner,
+  Notification,
+  NotificationSeverity,
+} from "@canonical/react-components";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+
+import type { EntityEntitlement } from "api/api.schemas";
+import { IdentityEntitlementsPatchItemAllOfOp } from "api/api.schemas";
+import {
+  useGetIdentitiesItemEntitlements,
+  usePatchIdentitiesItemEntitlements,
+} from "api/identities/identities";
+import EntitlementsPanelForm from "components/EntitlementsPanelForm";
+
+import { Label } from "./types";
+
+const updateEntitlements = (
+  userId: string,
+  entitlements: EntityEntitlement[],
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  op: IdentityEntitlementsPatchItemAllOfOp,
+  patchEntitlements: ReturnType<
+    typeof usePatchIdentitiesItemEntitlements
+  >["mutateAsync"],
+) => {
+  patchEntitlements({
+    id: userId,
+    data: {
+      patches: entitlements.map((entitlement) => ({
+        entitlement,
+        op,
+      })),
+    },
+  })
+    .then(() =>
+      queryClient.invalidateQueries({
+        queryKey,
+      }),
+    )
+    .catch(() => {
+      // this error is handled by the usePatchIdentitiesItemEntitlements hook.
+    });
+};
+
+const EntitlementsTab = () => {
+  const { id: userId } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const {
+    isError: isFetchError,
+    data,
+    isFetching,
+    isRefetching,
+    queryKey,
+  } = useGetIdentitiesItemEntitlements(userId ?? "");
+  const existingEntitlements = data?.data.data;
+  const {
+    mutateAsync,
+    isPending,
+    isError: isPatchError,
+  } = usePatchIdentitiesItemEntitlements();
+
+  if (!userId) {
+    // Loading states and errors for the user are handled in the parent
+    // `User` component.
+    return null;
+  }
+  if (isFetching && !isRefetching) {
+    return <Spinner />;
+  }
+  if (isFetchError) {
+    return (
+      <Notification severity={NotificationSeverity.NEGATIVE}>
+        {Label.FETCH_ENTITLEMENTS_ERROR}
+      </Notification>
+    );
+  }
+  if (isPatchError) {
+    return (
+      <Notification severity={NotificationSeverity.NEGATIVE}>
+        {Label.PATCH_ENTITLEMENTS_ERROR}
+      </Notification>
+    );
+  }
+  return (
+    <EntitlementsPanelForm
+      existingEntitlements={existingEntitlements}
+      setAddEntitlements={(addEntitlements) =>
+        updateEntitlements(
+          userId,
+          addEntitlements,
+          queryClient,
+          queryKey,
+          IdentityEntitlementsPatchItemAllOfOp.add,
+          mutateAsync,
+        )
+      }
+      setRemoveEntitlements={(removeEntitlements) =>
+        updateEntitlements(
+          userId,
+          removeEntitlements,
+          queryClient,
+          queryKey,
+          IdentityEntitlementsPatchItemAllOfOp.remove,
+          mutateAsync,
+        )
+      }
+      submitProps={{ loading: isPending }}
+    />
+  );
+};
+
+export default EntitlementsTab;

--- a/src/components/pages/Users/EntitlementsTab/index.ts
+++ b/src/components/pages/Users/EntitlementsTab/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./EntitlementsTab";
+export { Label as EntitlementsTabLabel } from "./types";

--- a/src/components/pages/Users/EntitlementsTab/types.ts
+++ b/src/components/pages/Users/EntitlementsTab/types.ts
@@ -1,0 +1,4 @@
+export enum Label {
+  FETCH_ENTITLEMENTS_ERROR = "Unable to get user's entitlements.",
+  PATCH_ENTITLEMENTS_ERROR = "Unable to update user's entitlements.",
+}

--- a/src/components/pages/Users/SummaryTab/SummaryTab.tsx
+++ b/src/components/pages/Users/SummaryTab/SummaryTab.tsx
@@ -6,7 +6,7 @@ import ListCard from "components/ListCard";
 
 const SummaryTab = () => {
   const { id: userId } = useParams<{ id: string }>();
-  // Loading states and errors for the user are handled in the parent component.
+  // Loading states and errors for the user are handled in the parent `User` component.
   const { data } = useGetIdentitiesItem(userId ?? "");
   const user = data?.data;
 

--- a/src/components/pages/Users/SummaryTab/index.ts
+++ b/src/components/pages/Users/SummaryTab/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./SummaryTab";
-export { Label as SummaryTabLabel } from "./types";

--- a/src/components/pages/Users/SummaryTab/types.ts
+++ b/src/components/pages/Users/SummaryTab/types.ts
@@ -1,3 +1,0 @@
-export enum Label {
-  LOADING = "Loading user.",
-}

--- a/src/mocks/entitlements.ts
+++ b/src/mocks/entitlements.ts
@@ -1,0 +1,12 @@
+import { faker } from "@faker-js/faker";
+
+import type { EntityEntitlement } from "api/api.schemas";
+
+export const mockEntityEntitlement = (
+  overrides?: Partial<EntityEntitlement>,
+): EntityEntitlement => ({
+  entitlement: faker.word.sample(),
+  entity_id: faker.word.sample(),
+  entity_type: faker.word.sample(),
+  ...overrides,
+});

--- a/src/mocks/resources.ts
+++ b/src/mocks/resources.ts
@@ -1,0 +1,15 @@
+import { faker } from "@faker-js/faker";
+
+import type { Entity, Resource } from "api/api.schemas";
+
+export const mockEntity = (overrides?: Partial<Entity>): Entity => ({
+  id: faker.word.sample(),
+  name: faker.word.sample(),
+  type: faker.word.sample(),
+  ...overrides,
+});
+
+export const mockResource = (overrides?: Partial<Resource>): Resource => ({
+  entity: mockEntity(),
+  ...overrides,
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,6 +1,6 @@
 import { NotificationSeverity } from "@canonical/react-components";
 import { QueryClient } from "@tanstack/react-query";
-import { render, renderHook, screen } from "@testing-library/react";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 import ComponentProviders from "./ComponentProviders";
@@ -82,4 +82,25 @@ export const hasToast = async (
   const card = toast.closest(".toast-card");
   expect(card).toBeInTheDocument();
   expect(card).toHaveAttribute("data-type", severity);
+};
+
+export const hasSpinner = async (label = "Loading", shouldExist = true) => {
+  if (shouldExist) {
+    const text = await screen.findByText(label);
+    const parent = text?.closest('[role="alert"]');
+    const icon = parent?.querySelector(".p-icon--spinner");
+    expect(text).toBeInTheDocument();
+    expect(icon).toBeInTheDocument();
+  } else {
+    await waitFor(() => {
+      const text = screen.queryByText(label);
+      if (text) {
+        const parent = text.closest('[role="alert"]');
+        const icon = parent?.querySelector(".p-icon--spinner");
+        expect(icon).not.toBeInTheDocument();
+      } else {
+        expect(text).not.toBeInTheDocument();
+      }
+    });
+  }
 };


### PR DESCRIPTION
## Done

- Add user entitlements tab.
- Add util for finding spinners.

## QA

Note: this will require the following fix to be able to delete entitlements: https://github.com/canonical/rebac-admin-ui-handlers/pull/23.
- Go to the users table and click on a user.
- Click on the 'Entitlements' tab.
- Use the form to add an entitlement and it should appear in the table.
- Click the delete icon and it should delete an entitlement.

## Details

https://warthogs.atlassian.net/browse/WD-12402
