### PR TITLE
feat: add multi-select component and add to roles form

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typecheck": "vitest --typecheck.only"
   },
   "peerDependencies": {
-    "@canonical/react-components": "^1.1.0",
+    "@canonical/react-components": "^1.2.0",
     "@tanstack/react-query": "^5.24.7",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -66,7 +66,7 @@
     "react-hot-toast": "2.4.1"
   },
   "devDependencies": {
-    "@canonical/react-components": "1.1.0",
+    "@canonical/react-components": "1.2.0",
     "@faker-js/faker": "8.4.1",
     "@mswjs/http-middleware": "0.10.1",
     "@tanstack/eslint-plugin-query": "5.32.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typecheck": "vitest --typecheck.only"
   },
   "peerDependencies": {
-    "@canonical/react-components": "^0.60.0",
+    "@canonical/react-components": "^1.1.0",
     "@tanstack/react-query": "^5.24.7",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -66,7 +66,7 @@
     "react-hot-toast": "2.4.1"
   },
   "devDependencies": {
-    "@canonical/react-components": "0.60.0",
+    "@canonical/react-components": "1.1.0",
     "@faker-js/faker": "8.4.1",
     "@mswjs/http-middleware": "0.10.1",
     "@tanstack/eslint-plugin-query": "5.32.1",
@@ -79,6 +79,7 @@
     "@types/cors": "2.8.17",
     "@types/express": "4.17.21",
     "@types/ip": "1.1.3",
+    "@types/lodash.isequal": "4",
     "@types/node": "20.12.11",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
@@ -103,6 +104,7 @@
     "formik": "2.4.6",
     "happy-dom": "14.10.1",
     "ip": "2.0.1",
+    "lodash.isequal": "4.5.0",
     "msw": "2.3.0",
     "npm-package-json-lint": "7.1.0",
     "orval": "6.28.2",

--- a/src/components/MultiSelectField/MultiSelectField.test.tsx
+++ b/src/components/MultiSelectField/MultiSelectField.test.tsx
@@ -1,0 +1,295 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import { hasSpinner } from "test/utils";
+
+import MultiSelectField from "./MultiSelectField";
+
+describe("MultiSelectField", () => {
+  test("calls onSearch", async () => {
+    const onSearch = vi.fn();
+    render(
+      <MultiSelectField
+        addEntities={[]}
+        entities={[]}
+        entityMatches={vi.fn()}
+        entityName="role"
+        generateItem={vi.fn()}
+        onSearch={onSearch}
+        removeEntities={[]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.type(
+      within(screen.getByRole("listbox")).getByRole("searchbox"),
+      "role1{enter}",
+    );
+    expect(onSearch).toHaveBeenCalledWith("role1");
+  });
+
+  // eslint-disable-next-line vitest/expect-expect
+  test("displays a spinner while searching", async () => {
+    render(
+      <MultiSelectField
+        addEntities={[]}
+        entities={[]}
+        entityMatches={vi.fn()}
+        entityName="role"
+        generateItem={vi.fn()}
+        isLoading={true}
+        onSearch={vi.fn()}
+        removeEntities={[]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.type(
+      within(screen.getByRole("listbox")).getByRole("searchbox"),
+      "role1{enter}",
+    );
+    await hasSpinner();
+  });
+
+  test("displays items", async () => {
+    render(
+      <MultiSelectField
+        addEntities={[]}
+        entities={[{ name: "role1", id: "role123" }]}
+        entityMatches={vi.fn()}
+        entityName="role"
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    expect(
+      screen.getByRole("checkbox", {
+        name: "role1",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("displays selected items", async () => {
+    render(
+      <MultiSelectField
+        addEntities={[{ name: "role4", id: "role456" }]}
+        entities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+          { name: "role4", id: "role456" },
+        ]}
+        entityMatches={vi.fn()}
+        entityName="role"
+        existingEntities={[
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+        ]}
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[{ name: "role2", id: "role234" }]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    expect(
+      screen.getByRole("checkbox", {
+        name: "role1",
+      }),
+    ).not.toBeChecked();
+    // Should not be selected because it is in removeEntities.
+    expect(
+      screen.getByRole("checkbox", {
+        name: "role2",
+      }),
+    ).not.toBeChecked();
+    // Should be selected because it is in existingEntities.
+    expect(
+      screen.getByRole("checkbox", {
+        name: "role3",
+      }),
+    ).toBeChecked();
+    // Should be selected because it is in addEntities.
+    expect(
+      screen.getByRole("checkbox", {
+        name: "role4",
+      }),
+    ).toBeChecked();
+  });
+
+  test("selects items", async () => {
+    const setAddEntities = vi.fn();
+    render(
+      <MultiSelectField
+        addEntities={[{ name: "role1", id: "role123" }]}
+        entities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+          { name: "role4", id: "role456" },
+        ]}
+        entityMatches={({ id }, { value }) => id === value}
+        entityName="role"
+        existingEntities={[]}
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[]}
+        setAddEntities={setAddEntities}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "role2",
+      }),
+    );
+    expect(setAddEntities).toHaveBeenCalledWith([
+      { name: "role1", id: "role123" },
+      { name: "role2", id: "role234" },
+    ]);
+  });
+
+  test("selects existing items that were previously deselected", async () => {
+    const setRemoveEntities = vi.fn();
+    render(
+      <MultiSelectField
+        addEntities={[]}
+        entities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+          { name: "role4", id: "role456" },
+        ]}
+        entityMatches={({ id }, { value }) => id === value}
+        entityName="role"
+        existingEntities={[{ name: "role1", id: "role123" }]}
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+        ]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={setRemoveEntities}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "role1",
+      }),
+    );
+    expect(setRemoveEntities).toHaveBeenCalledWith([
+      { name: "role2", id: "role234" },
+    ]);
+  });
+
+  test("deselects items", async () => {
+    const setAddEntities = vi.fn();
+    render(
+      <MultiSelectField
+        addEntities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+        ]}
+        entities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+          { name: "role4", id: "role456" },
+        ]}
+        entityMatches={({ id }, { value }) => id === value}
+        entityName="role"
+        existingEntities={[]}
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[]}
+        setAddEntities={setAddEntities}
+        setRemoveEntities={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "role2",
+      }),
+    );
+    expect(setAddEntities).toHaveBeenCalledWith([
+      { name: "role1", id: "role123" },
+    ]);
+  });
+
+  test("deselects existing items", async () => {
+    const setRemoveEntities = vi.fn();
+    render(
+      <MultiSelectField
+        addEntities={[]}
+        entities={[
+          { name: "role1", id: "role123" },
+          { name: "role2", id: "role234" },
+          { name: "role3", id: "role345" },
+          { name: "role4", id: "role456" },
+        ]}
+        entityMatches={({ id }, { value }) => id === value}
+        entityName="role"
+        existingEntities={[{ name: "role1", id: "role123" }]}
+        generateItem={(role) => ({ label: role.name, value: role.id })}
+        onSearch={vi.fn()}
+        removeEntities={[{ name: "role2", id: "role234" }]}
+        setAddEntities={vi.fn()}
+        setRemoveEntities={setRemoveEntities}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("combobox", {
+        name: "Select roles",
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: "role1",
+      }),
+    );
+    expect(setRemoveEntities).toHaveBeenCalledWith([
+      { name: "role2", id: "role234" },
+      { name: "role1", id: "role123" },
+    ]);
+  });
+});

--- a/src/components/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/MultiSelectField/MultiSelectField.tsx
@@ -32,59 +32,61 @@ const MultiSelectField = <E,>({
   ...selectProps
 }: Props<E>) => {
   return (
-    <MultiSelect
-      {...selectProps}
-      selectedItems={mapItems(
-        generateItem,
-        (existingEntities || [])
-          .concat(addEntities)
-          .filter(
-            (entity) =>
-              !removeEntities.find((removeEntity) =>
-                isEqual(entity, removeEntity),
-              ),
-          ),
-      )}
-      dropdownHeader={
-        <div className="multi-select-field__search">
-          <SearchBox onSearch={onSearch} shouldBlurOnSearch={false} />
-          {isLoading ? <Spinner /> : null}
-        </div>
-      }
-      items={mapItems(generateItem, entities)}
-      listSelected={false}
-      onDeselectItem={(item) => {
-        if (addEntities.find((entity) => entityMatches(entity, item))) {
-          setAddEntities(
-            addEntities.filter((entity) => !entityMatches(entity, item)),
-          );
-        } else {
-          const removeEntity = entities.find((entity) =>
-            entityMatches(entity, item),
-          );
-          if (removeEntity) {
-            setRemoveEntities([...removeEntities, removeEntity]);
-          }
+    <div className="multi-select-field">
+      <MultiSelect
+        {...selectProps}
+        selectedItems={mapItems(
+          generateItem,
+          (existingEntities || [])
+            .concat(addEntities)
+            .filter(
+              (entity) =>
+                !removeEntities.find((removeEntity) =>
+                  isEqual(entity, removeEntity),
+                ),
+            ),
+        )}
+        dropdownHeader={
+          <div className="multi-select-field__search">
+            <SearchBox onSearch={onSearch} />
+            {isLoading ? <Spinner /> : null}
+          </div>
         }
-      }}
-      onSelectItem={(item) => {
-        if (removeEntities.find((entity) => entityMatches(entity, item))) {
-          setRemoveEntities(
-            removeEntities.filter((entity) => !entityMatches(entity, item)),
-          );
-        } else {
-          const addEntity = entities.find((entity) =>
-            entityMatches(entity, item),
-          );
-          if (addEntity) {
-            setAddEntities([...addEntities, addEntity]);
+        items={mapItems(generateItem, entities)}
+        listSelected={false}
+        onDeselectItem={(item) => {
+          if (addEntities.find((entity) => entityMatches(entity, item))) {
+            setAddEntities(
+              addEntities.filter((entity) => !entityMatches(entity, item)),
+            );
+          } else {
+            const removeEntity = entities.find((entity) =>
+              entityMatches(entity, item),
+            );
+            if (removeEntity) {
+              setRemoveEntities([...removeEntities, removeEntity]);
+            }
           }
-        }
-      }}
-      placeholder={`Select ${pluralize(entityName)}`}
-      showDropdownFooter={false}
-      variant="condensed"
-    />
+        }}
+        onSelectItem={(item) => {
+          if (removeEntities.find((entity) => entityMatches(entity, item))) {
+            setRemoveEntities(
+              removeEntities.filter((entity) => !entityMatches(entity, item)),
+            );
+          } else {
+            const addEntity = entities.find((entity) =>
+              entityMatches(entity, item),
+            );
+            if (addEntity) {
+              setAddEntities([...addEntities, addEntity]);
+            }
+          }
+        }}
+        placeholder={`Select ${pluralize(entityName)}`}
+        showDropdownFooter={false}
+        variant="condensed"
+      />
+    </div>
   );
 };
 

--- a/src/components/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/MultiSelectField/MultiSelectField.tsx
@@ -1,0 +1,91 @@
+import type { MultiSelectItem } from "@canonical/react-components";
+import { MultiSelect, SearchBox, Spinner } from "@canonical/react-components";
+import isEqual from "lodash/isEqual";
+
+import { pluralize } from "utils";
+
+import type { Props } from "./types";
+
+import "./_multi-select-field.scss";
+
+const mapItems = <E,>(generateItem: Props<E>["generateItem"], entities: E[]) =>
+  entities.reduce<MultiSelectItem[]>((items, entity) => {
+    const item = generateItem(entity);
+    if (item) {
+      items.push(item);
+    }
+    return items;
+  }, []);
+
+const MultiSelectField = <E,>({
+  addEntities,
+  entityName,
+  existingEntities,
+  entities,
+  entityMatches,
+  generateItem,
+  isLoading,
+  onSearch,
+  removeEntities,
+  setAddEntities,
+  setRemoveEntities,
+  ...selectProps
+}: Props<E>) => {
+  return (
+    <MultiSelect
+      {...selectProps}
+      selectedItems={mapItems(
+        generateItem,
+        (existingEntities || [])
+          .concat(addEntities)
+          .filter(
+            (entity) =>
+              !removeEntities.find((removeEntity) =>
+                isEqual(entity, removeEntity),
+              ),
+          ),
+      )}
+      dropdownHeader={
+        <div className="multi-select-field__search">
+          <SearchBox onSearch={onSearch} shouldBlurOnSearch={false} />
+          {isLoading ? <Spinner /> : null}
+        </div>
+      }
+      items={mapItems(generateItem, entities)}
+      listSelected={false}
+      onDeselectItem={(item) => {
+        if (addEntities.find((entity) => entityMatches(entity, item))) {
+          setAddEntities(
+            addEntities.filter((entity) => !entityMatches(entity, item)),
+          );
+        } else {
+          const removeEntity = entities.find((entity) =>
+            entityMatches(entity, item),
+          );
+          if (removeEntity) {
+            setRemoveEntities([...removeEntities, removeEntity]);
+          }
+        }
+      }}
+      onSelectItem={(item) => {
+        if (removeEntities.find((entity) => entityMatches(entity, item))) {
+          setRemoveEntities(
+            removeEntities.filter((entity) => !entityMatches(entity, item)),
+          );
+        } else {
+          const addEntity = entities.find((entity) =>
+            entityMatches(entity, item),
+          );
+          if (addEntity) {
+            setAddEntities([...addEntities, addEntity]);
+          }
+        }
+      }}
+      placeholder={`Select ${pluralize(entityName)}`}
+      showDropdownFooter={false}
+      variant="condensed"
+    />
+  );
+};
+
+export default MultiSelectField;

--- a/src/components/MultiSelectField/_multi-select-field.scss
+++ b/src/components/MultiSelectField/_multi-select-field.scss
@@ -1,6 +1,8 @@
 @import "vanilla-framework/scss/vanilla";
 
 .multi-select-field {
+    margin-bottom: $input-margin-bottom;
+    
   &__search {
     padding: $sph--large $sph--large 0 $sph--large;
   }

--- a/src/components/MultiSelectField/_multi-select-field.scss
+++ b/src/components/MultiSelectField/_multi-select-field.scss
@@ -1,0 +1,7 @@
+@import "vanilla-framework/scss/vanilla";
+
+.multi-select-field {
+  &__search {
+    padding: $sph--large $sph--large 0 $sph--large;
+  }
+}

--- a/src/components/MultiSelectField/_multi-select-field.scss
+++ b/src/components/MultiSelectField/_multi-select-field.scss
@@ -1,8 +1,8 @@
 @import "vanilla-framework/scss/vanilla";
 
 .multi-select-field {
-    margin-bottom: $input-margin-bottom;
-    
+  margin-bottom: $input-margin-bottom;
+
   &__search {
     padding: $sph--large $sph--large 0 $sph--large;
   }

--- a/src/components/MultiSelectField/index.ts
+++ b/src/components/MultiSelectField/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./MultiSelectField";
+export type { Props as MultiSelectFieldProps } from "./MultiSelectField";

--- a/src/components/MultiSelectField/index.ts
+++ b/src/components/MultiSelectField/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./MultiSelectField";
-export type { Props as MultiSelectFieldProps } from "./MultiSelectField";
+export type { Props as MultiSelectFieldProps } from "./types";

--- a/src/components/MultiSelectField/types.ts
+++ b/src/components/MultiSelectField/types.ts
@@ -1,0 +1,22 @@
+import type {
+  MultiSelectProps,
+  PropsWithSpread,
+  MultiSelectItem,
+} from "@canonical/react-components";
+
+export type Props<E> = PropsWithSpread<
+  {
+    addEntities: E[];
+    entities: E[];
+    entityMatches: (entity: E, item: MultiSelectItem) => boolean;
+    entityName: string;
+    existingEntities?: E[];
+    generateItem: (item: E) => MultiSelectItem | null | undefined;
+    isLoading?: boolean;
+    onSearch: (searchValue: string) => void;
+    removeEntities: E[];
+    setAddEntities: (addEntities: E[]) => void;
+    setRemoveEntities: (removeEntities: E[]) => void;
+  },
+  Partial<MultiSelectProps>
+>;

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
@@ -34,11 +34,11 @@ import {
 } from "api/roles/roles.msw";
 import { EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
 import { EntitlementPanelFormFieldsLabel } from "components/EntitlementsPanelForm/Fields";
+import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm/types";
 import { hasNotification, hasToast, renderComponent } from "test/utils";
 
 import { GroupPanelLabel } from "../GroupPanel";
 import { Label as IdentitiesPanelFormLabel } from "../IdentitiesPanelForm/types";
-import { Label as RolesPanelFormLabel } from "../RolesPanelForm/types";
 
 import AddGroupPanel from "./AddGroupPanel";
 import { Label } from "./types";
@@ -350,18 +350,15 @@ test("should add roles", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add roles/ }));
-  // Wait for the options to load.
-  await screen.findByRole("option", {
-    name: "role3",
-  });
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: RolesPanelFormLabel.ROLE,
+      name: RolesPanelFormLabel.SELECT,
     }),
-    "role3",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "role3",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Create group" })[0],
@@ -385,18 +382,15 @@ test("should handle errors when adding roles", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add roles/ }));
-  // Wait for the options to load.
-  await screen.findByRole("option", {
-    name: "role3",
-  });
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: RolesPanelFormLabel.ROLE,
+      name: RolesPanelFormLabel.SELECT,
     }),
-    "role3",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "role3",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Create group" })[0],

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.test.tsx
@@ -383,14 +383,15 @@ test("should add and remove roles", async () => {
       name: RolesPanelFormLabel.REMOVE,
     })[0],
   );
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: RolesPanelFormLabel.ROLE,
+      name: RolesPanelFormLabel.SELECT,
     }),
-    "role3",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "role3",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Edit group" })[0],
@@ -398,7 +399,7 @@ test("should add and remove roles", async () => {
   await userEvent.click(screen.getByRole("button", { name: "Update group" }));
   await waitFor(() => expect(patchDone).toBe(true));
   expect(patchResponseBody).toBe(
-    '{"patches":[{"role":"role345","op":"add"},{"role":"role123","op":"remove"}]}',
+    '{"patches":[{"role":"role123","op":"remove"},{"role":"role345","op":"remove"}]}',
   );
   await hasToast('Group "admin" was updated.', "positive");
 });
@@ -417,18 +418,15 @@ test("should handle errors when updating roles", async () => {
   // Wait until the roles have loaded.
   await screen.findByText("3 roles");
   await userEvent.click(screen.getByRole("button", { name: /Edit roles/ }));
-  // Wait for the options to load.
-  await screen.findByRole("option", {
-    name: "role3",
-  });
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: RolesPanelFormLabel.ROLE,
+      name: RolesPanelFormLabel.SELECT,
     }),
-    "role3",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: RolesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "role3",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Edit group" })[0],

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import Limiter from "async-limiter";
 import type { AxiosError } from "axios";
 import reactHotToast from "react-hot-toast";
@@ -48,6 +49,7 @@ const generateError = (
 };
 
 const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
+  const queryClient = useQueryClient();
   const {
     error: getGroupsItemEntitlementsError,
     data: existingEntitlements,
@@ -70,6 +72,7 @@ const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
     error: getGroupsItemRolesError,
     data: existingRoles,
     isFetching: isFetchingExistingRoles,
+    queryKey,
   } = useGetGroupsItemRoles(groupId);
   const {
     mutateAsync: patchGroupsItemRoles,
@@ -205,6 +208,9 @@ const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
           });
         }
         queue.onDone(() => {
+          void queryClient.invalidateQueries({
+            queryKey,
+          });
           close();
           if (hasEntitlementsError) {
             reactHotToast.custom((t) => (

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
@@ -7,10 +7,10 @@ import { getGetEntitlementsMockHandler } from "api/entitlements/entitlements.msw
 import { getGetIdentitiesMockHandler } from "api/identities/identities.msw";
 import { getGetRolesMockHandler } from "api/roles/roles.msw";
 import { EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
+import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm/types";
 import { renderComponent } from "test/utils";
 
 import { Label as IdentitiesPanelFormLabel } from "../IdentitiesPanelForm";
-import { Label as RolesPanelFormLabel } from "../RolesPanelForm";
 
 import GroupPanel from "./GroupPanel";
 import { Label } from "./types";
@@ -102,7 +102,9 @@ test("the role form can be displayed", async () => {
 
   await userEvent.click(screen.getByRole("button", { name: /Add roles/ }));
   expect(
-    screen.getByRole("form", { name: RolesPanelFormLabel.FORM }),
+    screen.getByRole("combobox", {
+      name: RolesPanelFormLabel.SELECT,
+    }),
   ).toBeInTheDocument();
 });
 

--- a/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
+++ b/src/components/pages/Groups/RolesPanelForm/RolesPanelForm.tsx
@@ -1,19 +1,11 @@
-import type { SelectProps } from "@canonical/react-components";
-import { Select } from "@canonical/react-components";
-import { Form, Formik } from "formik";
-import * as Yup from "yup";
+import { useState } from "react";
 
 import type { Role } from "api/api.schemas";
 import { useGetRoles } from "api/roles/roles";
-import CleanFormikField from "components/CleanFormikField";
-import FormikSubmitButton from "components/FormikSubmitButton";
+import MultiSelectField from "components/MultiSelectField";
 import PanelTableForm from "components/PanelTableForm";
 
-import { Label, type Props } from "./types";
-
-const schema = Yup.object().shape({
-  id: Yup.string().required("Required"),
-});
+import { type Props } from "./types";
 
 const COLUMN_DATA = [
   {
@@ -32,32 +24,17 @@ const roleMatches = (role: Role, search: string) =>
   Object.values(role).some((value) => value.includes(search));
 
 const RolesPanelForm = ({
-  error,
   existingRoles,
   addRoles,
   setAddRoles,
   removeRoles,
   setRemoveRoles,
 }: Props) => {
-  const { data } = useGetRoles();
-  const roles = data?.data.data;
-  let options: NonNullable<SelectProps["options"]> = [
-    { value: "", label: "Select role" },
-  ];
-  options = options.concat(
-    roles?.reduce<NonNullable<SelectProps["options"]>>(
-      (options, { id, name }) => {
-        if (id) {
-          options.push({
-            value: id,
-            label: name,
-          });
-        }
-        return options;
-      },
-      [],
-    ) ?? [],
-  );
+  const [filter, setFilter] = useState("");
+  const { data, isFetching, error } = useGetRoles({
+    filter: filter || undefined,
+  });
+  const roles = data?.data.data || [];
   return (
     <PanelTableForm
       addEntities={addRoles}
@@ -65,38 +42,32 @@ const RolesPanelForm = ({
       entityEqual={roleEqual}
       entityMatches={roleMatches}
       entityName="role"
-      error={error}
+      error={error?.response?.data.message}
       existingEntities={existingRoles}
       form={
-        <Formik<{ id: string }>
-          initialValues={{ id: "" }}
-          onSubmit={({ id }, helpers) => {
-            const role = roles?.find((role) => role.id === id);
-            if (role) {
-              setAddRoles([...addRoles, role]);
-            }
-            helpers.resetForm();
-            document
-              .querySelector<HTMLSelectElement>("input[name='id']")
-              ?.focus();
-          }}
-          validationSchema={schema}
-        >
-          <Form aria-label={Label.FORM}>
-            <h5>Add roles</h5>
-            <div className="panel-table-form__fields">
-              <CleanFormikField
-                component={Select}
-                label={Label.ROLE}
-                name="id"
-                options={options}
-              />
-              <div className="panel-table-form__submit">
-                <FormikSubmitButton>{Label.SUBMIT}</FormikSubmitButton>
-              </div>
-            </div>
-          </Form>
-        </Formik>
+        <>
+          <h5>Add roles</h5>
+          <MultiSelectField
+            addEntities={addRoles}
+            entities={roles}
+            entityMatches={({ id }, { value }) => id === value}
+            entityName="role"
+            existingEntities={existingRoles}
+            generateItem={({ id, name }: Role) => {
+              if (id) {
+                return {
+                  value: id,
+                  label: name,
+                };
+              }
+            }}
+            isLoading={isFetching}
+            onSearch={setFilter}
+            removeEntities={removeRoles}
+            setAddEntities={setAddRoles}
+            setRemoveEntities={setRemoveRoles}
+          />
+        </>
       }
       generateCells={({ name }) => ({ name })}
       removeEntities={removeRoles}

--- a/src/components/pages/Groups/RolesPanelForm/types.ts
+++ b/src/components/pages/Groups/RolesPanelForm/types.ts
@@ -2,7 +2,6 @@ import type { Role } from "api/api.schemas";
 
 export type Props = {
   addRoles: Role[];
-  error?: string | null;
   existingRoles?: Role[];
   removeRoles: Role[];
   setAddRoles: (addRoles: Role[]) => void;
@@ -10,8 +9,6 @@ export type Props = {
 };
 
 export enum Label {
-  ROLE = "Role name",
-  FORM = "Add role",
+  SELECT = "Select roles",
   REMOVE = "Remove role",
-  SUBMIT = "Add",
 }

--- a/src/mocks/roles.ts
+++ b/src/mocks/roles.ts
@@ -1,0 +1,8 @@
+import { faker } from "@faker-js/faker";
+
+import type { Role } from "api/api.schemas";
+
+export const mockRole = (overrides?: Partial<Role>): Role => ({
+  name: faker.word.sample(),
+  ...overrides,
+});

--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -1,4 +1,4 @@
 .p-contextual-menu .p-contextual-menu__dropdown {
-    // Display contextual menus above panels (l-aside).
-    z-index: 102;
+  // Display contextual menus above panels (l-aside).
+  z-index: 102;
 }

--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -1,0 +1,4 @@
+.p-contextual-menu .p-contextual-menu__dropdown {
+    // Display contextual menus above panels (l-aside).
+    z-index: 102;
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -5,6 +5,7 @@
 @include vf-p-icon-profile;
 @include vf-p-icon-settings;
 @import "tables";
+@import "vanilla-overrides";
 
 .l-application .l-aside.is-medium {
   width: 45rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1873,9 +1873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/react-components@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@canonical/react-components@npm:1.1.0"
+"@canonical/react-components@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@canonical/react-components@npm:1.2.0"
   dependencies:
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:20.12.11"
@@ -1895,7 +1895,7 @@ __metadata:
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
     vanilla-framework: ^3.15.1 || ^4.0.0
-  checksum: 10c0/e83e7a401141a8fcb17954ac66e98ceacc09e98d8a1b12365bef003e182d2db33ef83a4ae541be23e680bb82eb0b61694d2a4b6b2d6c86ad9df0dded4c73e0e3
+  checksum: 10c0/71dd39654b87f60b45828b3c5059619adb9b68f22424f7fdc84a719cc6d8c3c1899ccf5eaa0fe06a5777888e513c625e7f050d87403d8f3a20edde3905f7961d
   languageName: node
   linkType: hard
 
@@ -1903,7 +1903,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canonical/rebac-admin@workspace:."
   dependencies:
-    "@canonical/react-components": "npm:1.1.0"
+    "@canonical/react-components": "npm:1.2.0"
     "@faker-js/faker": "npm:8.4.1"
     "@mswjs/http-middleware": "npm:0.10.1"
     "@tanstack/eslint-plugin-query": "npm:5.32.1"
@@ -1970,7 +1970,7 @@ __metadata:
     vitest: "npm:1.6.0"
     yup: "npm:1.4.0"
   peerDependencies:
-    "@canonical/react-components": ^1.1.0
+    "@canonical/react-components": ^1.2.0
     "@tanstack/react-query": ^5.24.7
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1873,9 +1873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@canonical/react-components@npm:0.60.0":
-  version: 0.60.0
-  resolution: "@canonical/react-components@npm:0.60.0"
+"@canonical/react-components@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@canonical/react-components@npm:1.1.0"
   dependencies:
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:20.12.11"
@@ -1895,7 +1895,7 @@ __metadata:
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
     vanilla-framework: ^3.15.1 || ^4.0.0
-  checksum: 10c0/8ed1e63784fe803404e9ddf0105c14fe5f6b78eaa80a1f2fb9a33fe56f953f94ca4dd21405f014fba5ba6bf0c244868adb6630a03acfd783043ceba99512e2eb
+  checksum: 10c0/e83e7a401141a8fcb17954ac66e98ceacc09e98d8a1b12365bef003e182d2db33ef83a4ae541be23e680bb82eb0b61694d2a4b6b2d6c86ad9df0dded4c73e0e3
   languageName: node
   linkType: hard
 
@@ -1903,7 +1903,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@canonical/rebac-admin@workspace:."
   dependencies:
-    "@canonical/react-components": "npm:0.60.0"
+    "@canonical/react-components": "npm:1.1.0"
     "@faker-js/faker": "npm:8.4.1"
     "@mswjs/http-middleware": "npm:0.10.1"
     "@tanstack/eslint-plugin-query": "npm:5.32.1"
@@ -1916,6 +1916,7 @@ __metadata:
     "@types/cors": "npm:2.8.17"
     "@types/express": "npm:4.17.21"
     "@types/ip": "npm:1.1.3"
+    "@types/lodash.isequal": "npm:4"
     "@types/node": "npm:20.12.11"
     "@types/react": "npm:18.3.1"
     "@types/react-dom": "npm:18.3.0"
@@ -1942,6 +1943,7 @@ __metadata:
     formik: "npm:2.4.6"
     happy-dom: "npm:14.10.1"
     ip: "npm:2.0.1"
+    lodash.isequal: "npm:4.5.0"
     loglevel: "npm:1.9.1"
     msw: "npm:2.3.0"
     npm-package-json-lint: "npm:7.1.0"
@@ -1968,7 +1970,7 @@ __metadata:
     vitest: "npm:1.6.0"
     yup: "npm:1.4.0"
   peerDependencies:
-    "@canonical/react-components": ^0.60.0
+    "@canonical/react-components": ^1.1.0
     "@tanstack/react-query": ^5.24.7
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
@@ -4021,6 +4023,22 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/lodash.isequal@npm:4":
+  version: 4.5.8
+  resolution: "@types/lodash.isequal@npm:4.5.8"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10c0/6db28cacf165d55421fbf2970ccfb1682a7b82b743bb7aba4398fa8ab98f1711fca2fe4afa1aa2b7b4afb3eff76c8aca13b22206f5efeb038d99e41300589bca
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.17.7
+  resolution: "@types/lodash@npm:4.17.7"
+  checksum: 10c0/40c965b5ffdcf7ff5c9105307ee08b782da228c01b5c0529122c554c64f6b7168fc8f11dc79aa7bae4e67e17efafaba685dc3a47e294dbf52a65ed2b67100561
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Done

- Add component to handle multi-selection of entities.
- Update roles form to use the multi-select.

## QA

- Go to groups page.
- Open the panel to add or edit a group.
- Open the roles form.
- Open the select and you should be able to select multiple roles.
- You can also perform searches, but filtering is not implemented in the rebac example API.

## Details

https://warthogs.atlassian.net/browse/WD-14233
https://warthogs.atlassian.net/browse/WD-12646


