### PR TITLE
WD-12647 - feat: add multi-select for users form

### DIFF
--- a/src/components/RolesPanelForm/RolesPanelForm.test.tsx
+++ b/src/components/RolesPanelForm/RolesPanelForm.test.tsx
@@ -183,7 +183,6 @@ test("filter roles", async () => {
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   mockApiServer.events.on("request:start", async ({ request }) => {
     const requestClone = request.clone();
-    console.log(requestClone.url);
     if (
       requestClone.method === "GET" &&
       requestClone.url.endsWith("/roles?filter=role1")

--- a/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
+++ b/src/components/pages/Groups/AddGroupPanel/AddGroupPanel.test.tsx
@@ -273,18 +273,15 @@ test("should add users", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add users/ }));
-  // Wait for the options to load.
-  await screen.findByRole("option", {
-    name: "user2@example.com",
-  });
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: IdentitiesPanelFormLabel.USER,
+      name: IdentitiesPanelFormLabel.SELECT,
     }),
-    "user2@example.com",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "user2@example.com",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Create group" })[0],
@@ -310,18 +307,15 @@ test("should handle errors when adding users", async () => {
     "group1",
   );
   await userEvent.click(screen.getByRole("button", { name: /Add users/ }));
-  // Wait for the options to load.
-  await screen.findByRole("option", {
-    name: "user2@example.com",
-  });
-  await userEvent.selectOptions(
+  await userEvent.click(
     screen.getByRole("combobox", {
-      name: IdentitiesPanelFormLabel.USER,
+      name: IdentitiesPanelFormLabel.SELECT,
     }),
-    "user2@example.com",
   );
   await userEvent.click(
-    screen.getByRole("button", { name: IdentitiesPanelFormLabel.SUBMIT }),
+    await screen.findByRole("checkbox", {
+      name: "user2@example.com",
+    }),
   );
   await userEvent.click(
     screen.getAllByRole("button", { name: "Create group" })[0],

--- a/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
+++ b/src/components/pages/Groups/EditGroupPanel/EditGroupPanel.tsx
@@ -63,6 +63,7 @@ const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
     error: getGroupsItemIdentitiesError,
     data: existingIdentities,
     isFetching: isFetchingExistingIdentities,
+    queryKey: identitiesQueryKey,
   } = useGetGroupsItemIdentities(groupId);
   const {
     mutateAsync: patchGroupsItemIdentities,
@@ -72,7 +73,7 @@ const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
     error: getGroupsItemRolesError,
     data: existingRoles,
     isFetching: isFetchingExistingRoles,
-    queryKey,
+    queryKey: rolesQueryKey,
   } = useGetGroupsItemRoles(groupId);
   const {
     mutateAsync: patchGroupsItemRoles,
@@ -209,7 +210,10 @@ const EditGroupPanel = ({ close, group, groupId, setPanelWidth }: Props) => {
         }
         queue.onDone(() => {
           void queryClient.invalidateQueries({
-            queryKey,
+            queryKey: rolesQueryKey,
+          });
+          void queryClient.invalidateQueries({
+            queryKey: identitiesQueryKey,
           });
           close();
           if (hasEntitlementsError) {

--- a/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
+++ b/src/components/pages/Groups/GroupPanel/GroupPanel.test.tsx
@@ -91,7 +91,7 @@ test("the user form can be displayed", async () => {
   );
   await userEvent.click(screen.getByRole("button", { name: /Add users/ }));
   expect(
-    screen.getByRole("form", { name: IdentitiesPanelFormLabel.FORM }),
+    screen.getByRole("combobox", { name: IdentitiesPanelFormLabel.SELECT }),
   ).toBeInTheDocument();
 });
 

--- a/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
+++ b/src/components/pages/Groups/IdentitiesPanelForm/IdentitiesPanelForm.tsx
@@ -1,19 +1,11 @@
-import type { SelectProps } from "@canonical/react-components";
-import { Select } from "@canonical/react-components";
-import { Form, Formik } from "formik";
-import * as Yup from "yup";
+import { useState } from "react";
 
 import type { Identity } from "api/api.schemas";
 import { useGetIdentities } from "api/identities/identities";
-import CleanFormikField from "components/CleanFormikField";
-import FormikSubmitButton from "components/FormikSubmitButton";
+import MultiSelectField from "components/MultiSelectField";
 import PanelTableForm from "components/PanelTableForm";
 
-import { Label, type Props } from "./types";
-
-const schema = Yup.object().shape({
-  id: Yup.string().required("Required"),
-});
+import { type Props } from "./types";
 
 const COLUMN_DATA = [
   {
@@ -32,32 +24,17 @@ const identityMatches = (identity: Identity, search: string) =>
   Object.values(identity).some((value) => value.includes(search));
 
 const IdentitiesPanelForm = ({
-  error,
   existingIdentities,
   addIdentities,
   setAddIdentities,
   removeIdentities,
   setRemoveIdentities,
 }: Props) => {
-  const { data } = useGetIdentities();
-  const users = data?.data.data;
-  let options: NonNullable<SelectProps["options"]> = [
-    { value: "", label: "Select user" },
-  ];
-  options = options.concat(
-    users?.reduce<NonNullable<SelectProps["options"]>>(
-      (options, { id, email }) => {
-        if (id) {
-          options.push({
-            value: id,
-            label: email,
-          });
-        }
-        return options;
-      },
-      [],
-    ) ?? [],
-  );
+  const [filter, setFilter] = useState("");
+  const { data, error, isFetching } = useGetIdentities({
+    filter: filter || undefined,
+  });
+  const users = data?.data.data ?? [];
   return (
     <PanelTableForm
       addEntities={addIdentities}
@@ -65,38 +42,32 @@ const IdentitiesPanelForm = ({
       entityEqual={identityEqual}
       entityMatches={identityMatches}
       entityName="user"
-      error={error}
+      error={error?.response?.data.message}
       existingEntities={existingIdentities}
       form={
-        <Formik<{ id: string }>
-          initialValues={{ id: "" }}
-          onSubmit={({ id }, helpers) => {
-            const user = users?.find((user) => user.id === id);
-            if (user) {
-              setAddIdentities([...addIdentities, user]);
-            }
-            helpers.resetForm();
-            document
-              .querySelector<HTMLInputElement>("input[name='id']")
-              ?.focus();
-          }}
-          validationSchema={schema}
-        >
-          <Form aria-label={Label.FORM}>
-            <h5>Add users</h5>
-            <div className="panel-table-form__fields">
-              <CleanFormikField
-                component={Select}
-                label={Label.USER}
-                name="id"
-                options={options}
-              />
-              <div className="panel-table-form__submit">
-                <FormikSubmitButton>{Label.SUBMIT}</FormikSubmitButton>
-              </div>
-            </div>
-          </Form>
-        </Formik>
+        <>
+          <h5>Add users</h5>
+          <MultiSelectField
+            addEntities={addIdentities}
+            entities={users}
+            entityMatches={({ id }, { value }) => id === value}
+            entityName="user"
+            existingEntities={existingIdentities}
+            generateItem={({ id, email }: Identity) => {
+              if (id) {
+                return {
+                  value: id,
+                  label: email,
+                };
+              }
+            }}
+            isLoading={isFetching}
+            onSearch={setFilter}
+            removeEntities={removeIdentities}
+            setAddEntities={setAddIdentities}
+            setRemoveEntities={setRemoveIdentities}
+          />
+        </>
       }
       generateCells={({ email }) => ({ email })}
       removeEntities={removeIdentities}

--- a/src/components/pages/Groups/IdentitiesPanelForm/types.ts
+++ b/src/components/pages/Groups/IdentitiesPanelForm/types.ts
@@ -2,7 +2,6 @@ import type { Identity } from "api/api.schemas";
 
 export type Props = {
   addIdentities: Identity[];
-  error?: string | null;
   existingIdentities?: Identity[];
   removeIdentities: Identity[];
   setAddIdentities: (addIdentities: Identity[]) => void;
@@ -10,8 +9,6 @@ export type Props = {
 };
 
 export enum Label {
-  USER = "Username",
-  FORM = "Add user",
   REMOVE = "Remove user",
-  SUBMIT = "Add",
+  SELECT = "Select users",
 }

--- a/src/components/pages/Users/AddUserPanel/AddUserPanel.test.tsx
+++ b/src/components/pages/Users/AddUserPanel/AddUserPanel.test.tsx
@@ -28,7 +28,7 @@ import {
 } from "api/roles/roles.msw";
 import { EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
 import { EntitlementPanelFormFieldsLabel } from "components/EntitlementsPanelForm/Fields";
-import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm";
+import { Label as RolesPanelFormLabel } from "components/RolesPanelForm";
 import { hasToast, renderComponent, hasNotification } from "test/utils";
 
 import { UserPanelLabel } from "../UserPanel";

--- a/src/components/pages/Users/UserPanel/UserPanel.test.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.test.tsx
@@ -6,7 +6,7 @@ import { vi } from "vitest";
 import { getGetEntitlementsMockHandler } from "api/entitlements/entitlements.msw";
 import { getGetRolesMockHandler } from "api/roles/roles.msw";
 import { EntitlementsPanelFormLabel } from "components/EntitlementsPanelForm";
-import { Label as RolesPanelFormLabel } from "components/pages/Groups/RolesPanelForm";
+import { Label as RolesPanelFormLabel } from "components/RolesPanelForm";
 import { renderComponent } from "test/utils";
 
 import UserPanel from "./UserPanel";

--- a/src/components/pages/Users/UserPanel/UserPanel.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.tsx
@@ -4,8 +4,8 @@ import * as Yup from "yup";
 import type { EntityEntitlement, Role } from "api/api.schemas";
 import CleanFormikField from "components/CleanFormikField";
 import EntitlementsPanelForm from "components/EntitlementsPanelForm";
+import RolesPanelForm from "components/RolesPanelForm";
 import SubFormPanel from "components/SubFormPanel";
-import RolesPanelForm from "components/pages/Groups/RolesPanelForm";
 
 import { FieldName, Label } from "./types";
 import type { FormFields, Props } from "./types";


### PR DESCRIPTION
## Done

- Add a multi-select for users subform.

## QA

- Go to groups page.
- Open the panel to add or edit a group.
- Open the users form.
- Open the select and you should be able to select multiple users.
- You can also perform searches, but filtering is not implemented in the rebac example API.

## Details

https://warthogs.atlassian.net/browse/WD-12647
