### PR TITLE
WD-12401 - feat: add user details groups tab

### DIFF
--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -15,6 +15,7 @@ import Roles from "components/pages/Roles";
 import Users from "components/pages/Users";
 import AccountManagementTab from "components/pages/Users/AccountManagementTab";
 import EntitlementsTab from "components/pages/Users/EntitlementsTab";
+import GroupsTab from "components/pages/Users/GroupsTab";
 import RolesTab from "components/pages/Users/RolesTab";
 import SummaryTab from "components/pages/Users/SummaryTab";
 import User from "components/pages/Users/User";
@@ -111,7 +112,7 @@ const ReBACAdmin = ({
               />
               <Route
                 path={urls.users.user.groups(null)}
-                element={<>Groups{/* TODO: display user groups */}</>}
+                element={<GroupsTab />}
               />
               <Route
                 path={urls.users.user.roles(null)}

--- a/src/components/pages/Users/GroupsTab/GroupsTab.test.tsx
+++ b/src/components/pages/Users/GroupsTab/GroupsTab.test.tsx
@@ -1,0 +1,205 @@
+import { NotificationSeverity } from "@canonical/react-components";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, delay } from "msw";
+import { setupServer } from "msw/node";
+
+import {
+  getGetGroupsMockHandler,
+  getGetGroupsResponseMock,
+} from "api/groups/groups.msw";
+import {
+  getPatchIdentitiesItemGroupsMockHandler,
+  getGetIdentitiesItemGroupsMockHandler,
+  getGetIdentitiesItemGroupsResponseMock,
+  getPatchIdentitiesItemGroupsMockHandler400,
+  getGetIdentitiesItemGroupsMockHandler400,
+} from "api/identities/identities.msw";
+import { Label as GroupsPanelFormLabel } from "components/GroupsPanelForm";
+import { hasNotification, hasSpinner, renderComponent } from "test/utils";
+import { Endpoint } from "types/api";
+import urls from "urls";
+
+import GroupsTab from "./GroupsTab";
+import { Label } from "./types";
+
+const path = urls.users.user.groups(null);
+const url = urls.users.user.groups({ id: "user1" });
+
+const mockApiServer = setupServer(
+  getPatchIdentitiesItemGroupsMockHandler(),
+  getGetIdentitiesItemGroupsMockHandler(
+    getGetIdentitiesItemGroupsResponseMock({
+      data: [
+        { id: "group123", name: "group1" },
+        { id: "group234", name: "group2" },
+      ],
+    }),
+  ),
+  getGetGroupsMockHandler(
+    getGetGroupsResponseMock({
+      data: [
+        { id: "group123", name: "group1" },
+        { id: "group234", name: "group2" },
+        { id: "group345", name: "group3" },
+      ],
+    }),
+  ),
+);
+
+beforeAll(() => {
+  mockApiServer.listen();
+});
+
+afterEach(() => {
+  mockApiServer.resetHandlers();
+});
+
+afterAll(() => {
+  mockApiServer.close();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("display fetch errors", async () => {
+  mockApiServer.use(getGetIdentitiesItemGroupsMockHandler400());
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await hasNotification(Label.FETCH_ERROR, NotificationSeverity.NEGATIVE);
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("display loading spinner", async () => {
+  mockApiServer.use(
+    http.get(`*/${Endpoint.IDENTITIES}/*`, async () => {
+      await delay(100);
+    }),
+  );
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await hasSpinner();
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("does not display loading spinner when refetching", async () => {
+  mockApiServer.use(
+    http.get(`*/${Endpoint.IDENTITIES}/*`, async () => {
+      await delay(100);
+    }),
+  );
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: GroupsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await hasSpinner(undefined, false);
+});
+
+test("should add groups", async () => {
+  let patchResponseBody: string | null = null;
+  let patchDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/identities/user1/groups")
+    ) {
+      patchResponseBody = await requestClone.text();
+      patchDone = true;
+    }
+  });
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    await screen.findByRole("combobox", {
+      name: GroupsPanelFormLabel.SELECT,
+    }),
+  );
+  await userEvent.click(
+    await screen.findByRole("checkbox", {
+      name: "group3",
+    }),
+  );
+  await waitFor(() => expect(patchDone).toBe(true));
+  expect(patchResponseBody && JSON.parse(patchResponseBody)).toStrictEqual({
+    patches: [
+      {
+        group: "group345",
+        op: "add",
+      },
+    ],
+  });
+});
+
+test("should remove groups", async () => {
+  let patchResponseBody: string | null = null;
+  let patchDone = false;
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  mockApiServer.events.on("request:start", async ({ request }) => {
+    const requestClone = request.clone();
+    if (
+      requestClone.method === "PATCH" &&
+      requestClone.url.endsWith("/identities/user1/groups")
+    ) {
+      patchResponseBody = await requestClone.text();
+      patchDone = true;
+    }
+  });
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: GroupsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await waitFor(() => expect(patchDone).toBe(true));
+  expect(patchResponseBody && JSON.parse(patchResponseBody)).toStrictEqual({
+    patches: [
+      {
+        group: "group123",
+        op: "remove",
+      },
+    ],
+  });
+});
+
+// eslint-disable-next-line vitest/expect-expect
+test("should handle errors when updating groups", async () => {
+  mockApiServer.use(
+    getGetIdentitiesItemGroupsMockHandler(
+      getGetIdentitiesItemGroupsResponseMock({
+        data: ["can_edit::moderators:collection", "can_remove::staff:team"],
+      }),
+    ),
+    getPatchIdentitiesItemGroupsMockHandler400(),
+    getGetIdentitiesItemGroupsMockHandler400(),
+  );
+  renderComponent(<GroupsTab />, {
+    path,
+    url,
+  });
+  await userEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: GroupsPanelFormLabel.REMOVE,
+      })
+    )[0],
+  );
+  await hasNotification(Label.PATCH_ERROR, NotificationSeverity.NEGATIVE);
+});

--- a/src/components/pages/Users/GroupsTab/GroupsTab.test.tsx
+++ b/src/components/pages/Users/GroupsTab/GroupsTab.test.tsx
@@ -16,6 +16,7 @@ import {
   getGetIdentitiesItemGroupsMockHandler400,
 } from "api/identities/identities.msw";
 import { Label as GroupsPanelFormLabel } from "components/GroupsPanelForm";
+import { mockGroup } from "mocks/groups";
 import { hasNotification, hasSpinner, renderComponent } from "test/utils";
 import { Endpoint } from "types/api";
 import urls from "urls";
@@ -30,18 +31,15 @@ const mockApiServer = setupServer(
   getPatchIdentitiesItemGroupsMockHandler(),
   getGetIdentitiesItemGroupsMockHandler(
     getGetIdentitiesItemGroupsResponseMock({
-      data: [
-        { id: "group123", name: "group1" },
-        { id: "group234", name: "group2" },
-      ],
+      data: [mockGroup({ id: "group123" }), mockGroup()],
     }),
   ),
   getGetGroupsMockHandler(
     getGetGroupsResponseMock({
       data: [
-        { id: "group123", name: "group1" },
-        { id: "group234", name: "group2" },
-        { id: "group345", name: "group3" },
+        mockGroup(),
+        mockGroup(),
+        mockGroup({ id: "group345", name: "group3" }),
       ],
     }),
   ),

--- a/src/components/pages/Users/GroupsTab/GroupsTab.tsx
+++ b/src/components/pages/Users/GroupsTab/GroupsTab.tsx
@@ -1,0 +1,110 @@
+import {
+  Spinner,
+  Notification,
+  NotificationSeverity,
+} from "@canonical/react-components";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
+
+import { IdentityGroupsPatchItemOp } from "api/api.schemas";
+import type { Group } from "api/api.schemas";
+import {
+  useGetIdentitiesItemGroups,
+  usePatchIdentitiesItemGroups,
+} from "api/identities/identities";
+import GroupsPanelForm from "components/GroupsPanelForm";
+import { getIds } from "utils/getIds";
+
+import { Label } from "./types";
+
+const updateGroups = (
+  userId: string,
+  groups: Group[],
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  op: IdentityGroupsPatchItemOp,
+  patchGroups: ReturnType<typeof usePatchIdentitiesItemGroups>["mutateAsync"],
+) => {
+  patchGroups({
+    id: userId,
+    data: {
+      patches: getIds(groups).map((groupId) => ({
+        group: groupId,
+        op,
+      })),
+    },
+  })
+    .then(() =>
+      queryClient.invalidateQueries({
+        queryKey,
+      }),
+    )
+    .catch(() => {
+      // this error is handled by the usePatchIdentitiesItemGroups hook.
+    });
+};
+
+const GroupsTab = () => {
+  const { id: userId } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const {
+    isError: isFetchError,
+    data,
+    isFetching,
+    isRefetching,
+    queryKey,
+  } = useGetIdentitiesItemGroups(userId ?? "");
+  const existingGroups = data?.data.data;
+  const { mutateAsync, isError: isPatchError } = usePatchIdentitiesItemGroups();
+
+  if (!userId) {
+    // Loading states and errors for the user are handled in the parent
+    // `User` component.
+    return null;
+  }
+  if (isFetching && !isRefetching) {
+    return <Spinner />;
+  }
+  if (isFetchError) {
+    return (
+      <Notification severity={NotificationSeverity.NEGATIVE}>
+        {Label.FETCH_ERROR}
+      </Notification>
+    );
+  }
+  if (isPatchError) {
+    return (
+      <Notification severity={NotificationSeverity.NEGATIVE}>
+        {Label.PATCH_ERROR}
+      </Notification>
+    );
+  }
+  return (
+    <GroupsPanelForm
+      existingGroups={existingGroups}
+      setAddGroups={(addGroups) =>
+        updateGroups(
+          userId,
+          addGroups,
+          queryClient,
+          queryKey,
+          IdentityGroupsPatchItemOp.add,
+          mutateAsync,
+        )
+      }
+      setRemoveGroups={(removeGroups) =>
+        updateGroups(
+          userId,
+          removeGroups,
+          queryClient,
+          queryKey,
+          IdentityGroupsPatchItemOp.remove,
+          mutateAsync,
+        )
+      }
+    />
+  );
+};
+
+export default GroupsTab;

--- a/src/components/pages/Users/GroupsTab/index.ts
+++ b/src/components/pages/Users/GroupsTab/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./GroupsTab";
+export { Label as GroupsTabLabel } from "./types";

--- a/src/components/pages/Users/GroupsTab/types.ts
+++ b/src/components/pages/Users/GroupsTab/types.ts
@@ -1,0 +1,4 @@
+export enum Label {
+  FETCH_ERROR = "Unable to get user's groups.",
+  PATCH_ERROR = "Unable to update user's groups.",
+}


### PR DESCRIPTION
## Done

- Add groups tab to user's details.

## QA

- Click on a user in the users table and click on the groups tab.
- Check that you can add/remove groups.

## Details

https://warthogs.atlassian.net/browse/WD-12401
https://warthogs.atlassian.net/browse/WD-12410