### PR TITLE
WD-12405 - feat: add user details edit form

### DIFF
--- a/src/components/pages/Users/User/User.tsx
+++ b/src/components/pages/Users/User/User.tsx
@@ -100,18 +100,16 @@ const User = () => {
     content = <Outlet />;
   }
 
-  const generateEditUserButton = () => (
-    <Button
-      appearance={ButtonAppearance.DEFAULT}
-      onClick={() => openPanel({ editUser: user })}
-    >
-      <Icon name="edit" /> {Label.EDIT}
-    </Button>
-  );
-
   return (
     <Content
-      controls={generateEditUserButton()}
+      controls={
+        <Button
+          appearance={ButtonAppearance.DEFAULT}
+          onClick={() => openPanel({ editUser: user })}
+        >
+          <Icon name="edit" /> {Label.EDIT}
+        </Button>
+      }
       title={
         <BreadcrumbNavigation
           backTitle="Users"

--- a/src/components/pages/Users/User/User.tsx
+++ b/src/components/pages/Users/User/User.tsx
@@ -1,4 +1,10 @@
-import { Spinner, Tabs } from "@canonical/react-components";
+import {
+  Button,
+  ButtonAppearance,
+  Spinner,
+  Tabs,
+  Icon,
+} from "@canonical/react-components";
 import type { ReactNode } from "react";
 import type { UIMatch } from "react-router-dom";
 import {
@@ -9,12 +15,16 @@ import {
   useParams,
 } from "react-router-dom";
 
+import type { Identity } from "api/api.schemas";
 import { useGetIdentitiesItem } from "api/identities/identities";
 import BreadcrumbNavigation from "components/BreadcrumbNavigation";
 import Content from "components/Content";
 import ErrorNotification from "components/ErrorNotification";
+import { usePanel } from "hooks";
 import { Endpoint } from "types/api";
 import urls from "urls";
+
+import EditUserPanel from "../EditUserPanel";
 
 import { Label } from "./types";
 
@@ -33,6 +43,22 @@ const User = () => {
   const navigate = useNavigate();
   const matches = useMatches();
   const user = data?.data;
+
+  const { generatePanel, openPanel } = usePanel<{
+    editUser?: Identity | null;
+  }>((closePanel, data, setPanelWidth) => {
+    if (data?.editUser?.id) {
+      return (
+        <EditUserPanel
+          close={closePanel}
+          user={data.editUser}
+          userId={data.editUser.id}
+          setPanelWidth={setPanelWidth}
+        />
+      );
+    }
+    return null;
+  });
 
   const tabs = userId
     ? [
@@ -74,8 +100,18 @@ const User = () => {
     content = <Outlet />;
   }
 
+  const generateEditUserButton = () => (
+    <Button
+      appearance={ButtonAppearance.DEFAULT}
+      onClick={() => openPanel({ editUser: user })}
+    >
+      <Icon name="edit" /> {Label.EDIT}
+    </Button>
+  );
+
   return (
     <Content
+      controls={generateEditUserButton()}
       title={
         <BreadcrumbNavigation
           backTitle="Users"
@@ -104,6 +140,7 @@ const User = () => {
         }))}
       />
       {content}
+      {generatePanel()}
     </Content>
   );
 };

--- a/src/components/pages/Users/User/types.ts
+++ b/src/components/pages/Users/User/types.ts
@@ -2,4 +2,5 @@ export enum Label {
   FETCHING_USER = "Fetching user data...",
   FETCHING_USER_ERROR = "Couldn't fetch user data.",
   NO_USER = "User not found.",
+  EDIT = "Edit",
 }

--- a/src/components/pages/Users/UserPanel/UserPanel.test.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.test.tsx
@@ -191,5 +191,5 @@ test("should have submit button enabled if there are changes", async () => {
   );
   expect(
     screen.getByRole("button", { name: "Update local user" }),
-  ).not.toBeDisabled();
+  ).toBeEnabled();
 });

--- a/src/components/pages/Users/UserPanel/UserPanel.test.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.test.tsx
@@ -154,22 +154,3 @@ test("should have submit button disabled if there are no changes", async () => {
     screen.getByRole("button", { name: "Update local user" }),
   ).toBeDisabled();
 });
-
-test("should have submit button enabled if there are changes", async () => {
-  renderComponent(
-    <UserPanel
-      close={vi.fn()}
-      setPanelWidth={vi.fn()}
-      onSubmit={vi.fn()}
-      isEditing
-      user={mockUser}
-    />,
-  );
-  await userEvent.type(
-    screen.getByRole("textbox", { name: Label.EMAIL }),
-    "new-email@gmail.com",
-  );
-  expect(
-    screen.getByRole("button", { name: "Update local user" }),
-  ).toBeEnabled();
-});

--- a/src/components/pages/Users/UserPanel/UserPanel.test.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.test.tsx
@@ -154,3 +154,42 @@ test("should have submit button disabled if there are no changes", async () => {
     screen.getByRole("button", { name: "Update local user" }),
   ).toBeDisabled();
 });
+
+test("should have submit button enabled if there are changes", async () => {
+  renderComponent(
+    <UserPanel
+      close={vi.fn()}
+      setPanelWidth={vi.fn()}
+      onSubmit={vi.fn()}
+      existingEntitlements={[
+        {
+          entitlement: "can_edit",
+          entity_id: "moderators",
+          entity_type: "collection",
+        },
+        {
+          entitlement: "can_remove",
+          entity_id: "staff",
+          entity_type: "team",
+        },
+      ]}
+      isEditing
+      user={mockUser}
+    />,
+  );
+  await userEvent.click(
+    screen.getByRole("button", { name: /Edit entitlements/ }),
+  );
+  await screen.findByText(EntitlementsPanelFormLabel.ADD_ENTITLEMENT);
+  await userEvent.click(
+    screen.getAllByRole("button", {
+      name: EntitlementsPanelFormLabel.REMOVE,
+    })[0],
+  );
+  await userEvent.click(
+    screen.getAllByRole("button", { name: "Update local user" })[0],
+  );
+  expect(
+    screen.getByRole("button", { name: "Update local user" }),
+  ).not.toBeDisabled();
+});

--- a/src/components/pages/Users/UserPanel/UserPanel.tsx
+++ b/src/components/pages/Users/UserPanel/UserPanel.tsx
@@ -128,17 +128,20 @@ const UserPanel = ({
     >
       <h5>Personal details</h5>
       <CleanFormikField
+        disabled={isEditing}
         label={Label.EMAIL}
         name={FieldName.EMAIL}
-        takeFocus={true}
+        takeFocus={!isEditing}
         type="email"
       />
       <CleanFormikField
+        disabled={isEditing}
         label={Label.FIRST_NAME}
         name={FieldName.FIRST_NAME}
         type="text"
       />
       <CleanFormikField
+        disabled={isEditing}
         label={Label.LAST_NAME}
         name={FieldName.LAST_NAME}
         type="text"


### PR DESCRIPTION
## Done

- Add user details edit form.

## QA

- Navigate to users page and click on any of the user to open the user details page.
- Check that the edit button appears on the top right corner and that it opens the edit users panel.

## Details

- https://warthogs.atlassian.net/browse/WD-12405
