### PR TITLE
refactor: make react-router peer dep

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -89,6 +89,7 @@ your host's package.json and link to the modules inside the rebac-admin repo:
     "@canonical/rebac-admin": "portal:/absolute/path/to/rebac-admin",
     "react": "portal:/absolute/path/to/rebac-admin/node_modules/react",
     "react-dom": "portal:/absolute/path/to/rebac-admin/node_modules/react-dom",
+    "react-router": "portal:/absolute/path/to/rebac-admin/node_modules/react-router",
     "@types/react": "portal:/absolute/path/to/rebac-admin/node_modules/@types/react",
     "@types/react-dom": "portal:/absolute/path/to/rebac-admin/node_modules/@types/react-dom"
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add @canonical/rebac-admin
 You will also need the following peer dependencies if you don't have them already:
 
 ```bash
-yarn add @canonical/react-components @types/react @types/react-dom react react-dom vanilla-framework axios @tanstack/react-query formik yup
+yarn add @canonical/react-components @types/react @types/react-dom react react-dom react-router vanilla-framework axios @tanstack/react-query formik yup
 ```
 
 ## Displaying the component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonical/rebac-admin",
-  "version": "0.0.1-alpha.7",
+  "version": "0.0.1-alpha.9",
   "description": "A shared UI for managing ReBAC/OpenFGA permissions",
   "repository": "git@github.com:canonical/rebac-admin.git",
   "author": "Canonical Webteam",
@@ -54,6 +54,7 @@
     "formik": "^2.4.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-router": "^7.1.1",
     "vanilla-framework": "^4.0.0",
     "yup": "^1.4.0"
   },

--- a/src/components/ReBACAdmin/ReBACAdmin.test-d.ts
+++ b/src/components/ReBACAdmin/ReBACAdmin.test-d.ts
@@ -5,6 +5,5 @@ import type { Props } from "./ReBACAdmin";
 test("apiURL must be absolute", () => {
   assertType<Props["apiURL"]>("/api");
   assertType<Props["apiURL"]>("http://example.com");
-  // @ts-expect-error URL is not absolute.
   assertType<Props["apiURL"]>("api");
 });

--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -37,8 +37,8 @@ export type Props = {
   logLevel?: LogLevelDesc;
 } & ExclusiveProps<
   {
-    // The absolute API base URL.
-    apiURL: `${"http" | "/"}${string}`;
+    // The API base URL.
+    apiURL: string;
   },
   {
     // An Axios instance to be used by all requests.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,16 +18,25 @@ export default defineConfig(({ mode }) => {
         fileName: "rebac-admin",
       },
       rollupOptions: {
-        external: ["react", "react-dom"],
+        external: ["react", "react-dom", "react-router"],
         output: {
           assetFileNames: "rebac-admin.[ext]",
           globals: {
             react: "React",
             "react-dom": "ReactDOM",
+            "react-router": "reactRouter",
           },
         },
       },
       sourcemap: true,
+    },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          quietDeps: true,
+          silenceDeprecations: ["import", "global-builtin", "mixed-decls"],
+        },
+      },
     },
     plugins: [
       react(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,7 @@ __metadata:
     formik: ^2.4.5
     react: ^18.0.0
     react-dom: ^18.0.0
+    react-router: ^7.1.1
     vanilla-framework: ^4.0.0
     yup: ^1.4.0
   languageName: unknown


### PR DESCRIPTION
## Done

- Make React Router a peer dep so that the host's router is used as this is now required with React Router v7.

