### PR TITLE
build: Remove node polyfill configuration to fix build

### DIFF
--- a/src/components/ReBACAdmin/ReBACAdmin.tsx
+++ b/src/components/ReBACAdmin/ReBACAdmin.tsx
@@ -30,6 +30,14 @@ import { logger } from "utils";
 import "scss/index.scss";
 import { Label } from "./types";
 
+// Webpack 5 no longer makes node variables available at runtime so we need to
+// attach `process` to the window:
+// https://github.com/facebook/create-react-app/issues/12212
+// This is used by the async limiter.
+if (!window.process) {
+  window.process = process;
+}
+
 export type Props = {
   // The element ID to use to render aside panels into. Should not begin with "#".
   asidePanelId?: string | null;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import { resolve } from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 import dts from "vite-plugin-dts";
-import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig(({ mode }) => {
@@ -45,12 +44,6 @@ export default defineConfig(({ mode }) => {
         rollupTypes: true,
         include: ["src"],
         exclude: ["**/*.msw.ts", "src/test"],
-      }),
-      nodePolyfills({
-        globals: {
-          // Required by async-limiter.
-          process: true,
-        },
       }),
     ],
     publicDir: "demo/public",


### PR DESCRIPTION
## Done

- Removed the node polyfill configuration from the `vite.config.ts`
- Resolves the production build error that comes up after integration with juju-dashboard (and probably others)

# QA

- Run production build of this fix to see if there are any errors

## Details

https://warthogs.atlassian.net/browse/WD-18922